### PR TITLE
*: add OWNERS file and downstream Dockerfiles

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,0 +1,19 @@
+# use grafana/loki-build-image to compile binaries
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+ARG GOARCH="amd64"
+WORKDIR /go/src/github.com/grafana/loki
+COPY . .
+RUN touch loki-build-image/.uptodate && mkdir /build
+RUN make BUILD_IN_CONTAINER=false cmd/loki/loki
+
+FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+LABEL io.k8s.display-name="OpenShift Loki" \
+      io.k8s.description="Horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus." \
+      io.openshift.tags="grafana,prometheus,monitoring" \
+      maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
+      version="v0.2.0"
+
+COPY --from=builder /go/src/github.com/grafana/loki/cmd/loki/loki /usr/bin/loki
+COPY --from=builder /go/src/github.com/grafana/loki/cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
+EXPOSE 80
+ENTRYPOINT ["/usr/bin/loki"]

--- a/Dockerfile.promtail.ocp
+++ b/Dockerfile.promtail.ocp
@@ -1,0 +1,19 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
+ARG GOARCH="amd64"
+WORKDIR /go/src/github.com/grafana/loki
+COPY . .
+RUN touch loki-build-image/.uptodate && mkdir /build
+RUN make BUILD_IN_CONTAINER=false cmd/promtail/promtail
+
+FROM  registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+LABEL io.k8s.display-name="OpenShift Loki Promtail" \
+      io.k8s.description="An agent responsible for gathering logs and sending them to Loki." \
+      io.openshift.tags="grafana,prometheus,monitoring" \
+      maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
+      version="v0.2.0"
+
+COPY --from=builder /go/src/github.com/grafana/loki/cmd/promtail/promtail /usr/bin/promtail
+COPY --from=builder /go/src/github.com/grafana/loki/cmd/promtail/promtail-local-config.yaml \
+		    /go/src/github.com/grafana/loki/cmd/promtail/promtail-docker-config.yaml \
+		    /etc/promtail/
+ENTRYPOINT ["/usr/bin/promtail"]

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,17 @@
+reviewers:
+- brancz
+- kakkoyun
+- LiliC
+- metalmatze
+- paulfantom
+- s-urbaniak
+- squat
+
+approvers:
+- brancz
+- kakkoyun
+- LiliC
+- metalmatze
+- paulfantom
+- s-urbaniak
+- squat


### PR DESCRIPTION
Adding OWNERS file and downstream Dockerfiles.

Dockerfiles are split from `build/Dockerfile` and use UBI as a base.

This is needed to set up prow correctly. Merge with GitHub button as prow commands are not available until https://github.com/openshift/release/pull/4672 is merged.

/cc @brancz 
