### PR TITLE
Update rhel8 based Dockerfiles for Loki

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,18 +1,17 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
 ARG GOARCH="amd64"
 WORKDIR /go/src/github.com/grafana/loki
 COPY . .
 RUN touch loki-build-image/.uptodate && mkdir /build
-RUN make clean && make touch-protos && make BUILD_IN_CONTAINER=false cmd/loki/loki
+RUN make clean && make BUILD_IN_CONTAINER=false loki
 
-FROM  registry.ci.openshift.org/ocp/4.8:base
+FROM  registry.ci.openshift.org/ocp/4.10:base
 LABEL io.k8s.display-name="OpenShift Loki" \
       io.k8s.description="Horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus." \
       io.openshift.tags="grafana,prometheus,monitoring" \
       maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
-      version="v2.2.1"
+      version="v2.4.2"
 
 COPY --from=builder /go/src/github.com/grafana/loki/cmd/loki/loki /usr/bin/loki
 COPY --from=builder /go/src/github.com/grafana/loki/cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
-EXPOSE 80
 ENTRYPOINT ["/usr/bin/loki"]

--- a/Dockerfile.promtail.ocp
+++ b/Dockerfile.promtail.ocp
@@ -1,19 +1,19 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.8 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
 ARG GOARCH="amd64"
 WORKDIR /go/src/github.com/grafana/loki
 COPY . .
 RUN touch loki-build-image/.uptodate && mkdir /build
-RUN make clean && make touch-protos && make BUILD_IN_CONTAINER=false clients/cmd/promtail/promtail
+RUN make clean && make BUILD_IN_CONTAINER=false promtail
 
-FROM  registry.ci.openshift.org/ocp/4.8:base
+FROM  registry.ci.openshift.org/ocp/4.10:base
 LABEL io.k8s.display-name="OpenShift Loki Promtail" \
       io.k8s.description="An agent responsible for gathering logs and sending them to Loki." \
       io.openshift.tags="grafana,prometheus,monitoring" \
       maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
-      version="v2.2.1"
+      version="v2.4.2"
 
 COPY --from=builder /go/src/github.com/grafana/loki/clients/cmd/promtail/promtail /usr/bin/promtail
 COPY --from=builder /go/src/github.com/grafana/loki/clients/cmd/promtail/promtail-local-config.yaml \
-		    /go/src/github.com/grafana/loki/clients/cmd/promtail/promtail-docker-config.yaml \
-		    /etc/promtail/
+                    /go/src/github.com/grafana/loki/clients/cmd/promtail/promtail-docker-config.yaml \
+                    /etc/promtail/
 ENTRYPOINT ["/usr/bin/promtail"]


### PR DESCRIPTION
This updates the Dockerfiles in main to match `upstream-2.4.2`.

One question:
- Is `4.10` is correct OCP version to target or should it be a newer one?


