### PR TITLE
[release-5.5] Backport bugfixes from main

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Main
 
+- [7000](https://github.com/grafana/loki/pull/7000) **xperimental**: Configure default node affinity for all pods
+- [6923](https://github.com/grafana/loki/pull/6923) **xperimental**: Reconcile owner reference for existing objects
+- [6907](https://github.com/grafana/loki/pull/6907) **Red-GV**: Adding valid subscription annotation to operator metadata
 - [6479](https://github.com/grafana/loki/pull/6749) **periklis**: Update Loki operand to v2.6.1
 - [6748](https://github.com/grafana/loki/pull/6748) **periklis**: Update go4.org/unsafe/assume-no-moving-gc to latest
 - [6741](https://github.com/grafana/loki/pull/6741) **aminesnow**: Golang version to 1.18 and k8s client to 1.24

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Main
 
+- [7037](https://github.com/grafana/loki/pull/7037) **xperimental**: Skip enforcing matcher for certain tenants on OpenShift
+- [7106](https://github.com/grafana/loki/pull/7106) **xperimental**: Manage global stream-based retention
+- [7092](https://github.com/grafana/loki/pull/7092) **aminesnow**: Configure kube-rbac-proxy sidecar to use Intermediate TLS security profile in OCP
+- [6870](https://github.com/grafana/loki/pull/6870) **aminesnow**: Configure gateway to honor the global tlsSecurityProfile on Openshift
 - [6999](https://github.com/grafana/loki/pull/6999) **Red-GV**: Adding LokiStack Gateway alerts
 - [7000](https://github.com/grafana/loki/pull/7000) **xperimental**: Configure default node affinity for all pods
 - [6923](https://github.com/grafana/loki/pull/6923) **xperimental**: Reconcile owner reference for existing objects

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [6999](https://github.com/grafana/loki/pull/6999) **Red-GV**: Adding LokiStack Gateway alerts
 - [7000](https://github.com/grafana/loki/pull/7000) **xperimental**: Configure default node affinity for all pods
 - [6923](https://github.com/grafana/loki/pull/6923) **xperimental**: Reconcile owner reference for existing objects
 - [6907](https://github.com/grafana/loki/pull/6907) **Red-GV**: Adding valid subscription annotation to operator metadata

--- a/operator/apis/config/v1/projectconfig_types.go
+++ b/operator/apis/config/v1/projectconfig_types.go
@@ -67,6 +67,10 @@ type FeatureGates struct {
 	// RecordingRuleWebhook enables the RecordingRule CR validation webhook.
 	RecordingRuleWebhook bool `json:"recordingRuleWebhook,omitempty"`
 
+	// When DefaultNodeAffinity is enabled the operator will set a default node affinity on all pods.
+	// This will limit scheduling of the pods to Nodes with Linux.
+	DefaultNodeAffinity bool `json:"defaultNodeAffinity,omitempty"`
+
 	// OpenShift contains a set of feature gates supported only on OpenShift.
 	OpenShift OpenShiftFeatureGates `json:"openshift,omitempty"`
 }

--- a/operator/bundle/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -32,6 +32,7 @@ data:
       lokiStackGateway: true
       grafanaLabsUsageReport: false
       runtimeSeccompProfile: false
+      defaultNodeAffinity: true
       #
       # Webhook feature gates
       #

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -908,7 +908,7 @@ spec:
     The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
     ## Prerequisites and Requirements
     ### Loki Operator Namespace
-    The Loki Operator must be deployed to the global operator group namespace `openshift-logging`.
+    The Loki Operator must be deployed to the global operator group namespace `openshift-operators-redhat`.
     ### Memory Considerations
     Loki is a memory intensive application.  The initial
     set of OCP nodes may not be large enough to support the Loki cluster.  Additional OCP nodes must be added

--- a/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
@@ -1182,7 +1182,7 @@ spec:
     The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
     ## Prerequisites and Requirements
     ### Loki Operator Namespace
-    The Loki Operator must be deployed to the global operator group namespace `openshift-logging`.
+    The Loki Operator must be deployed to the global operator group namespace `openshift-operators-redhat`.
     ### Memory Considerations
     Loki is a memory intensive application.  The initial
     set of OCP nodes may not be large enough to support the Loki cluster.  Additional OCP nodes must be added

--- a/operator/config/overlays/openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/openshift/controller_manager_config.yaml
@@ -29,6 +29,7 @@ featureGates:
   lokiStackGateway: true
   grafanaLabsUsageReport: false
   runtimeSeccompProfile: false
+  defaultNodeAffinity: true
   #
   # Webhook feature gates
   #

--- a/operator/docs/lokistack/sop.md
+++ b/operator/docs/lokistack/sop.md
@@ -34,8 +34,8 @@ A service(s) is failing to process at least 10% of all incoming requests.
 - Console access to the cluster
 - Edit access to the deployed operator and Loki namespace:
   - OpenShift
-    - `openshift-logging`
-    - `openshift-operators-redhat`
+    - `openshift-logging` (LokiStack)
+    - `openshift-operators-redhat` (Loki Operator)
 
 ### Steps
 
@@ -46,6 +46,69 @@ A service(s) is failing to process at least 10% of all incoming requests.
     - `loki_ingester_wal_disk_full_failures_total`
     - `loki_ingester_wal_corruptions_total`
 
+## LokiStack Write Request Errors
+
+### Impact
+
+The LokiStack Gateway component is unable to perform its duties for a number of write requests, resulting in potential loss of data.
+
+### Summary
+
+The LokiStack Gateway is failing to process at least 10% of all incoming write requests.
+
+### Severity
+
+`Critical`
+
+### Access Required
+
+- Console access to the cluster
+- Edit access to the deployed operator and Loki namespace:
+  - OpenShift
+    - `openshift-logging` (LokiStack)
+    - `openshift-operators-redhat` (Loki Operator)
+
+### Steps
+
+- Ensure that the LokiStack Gateway component is ready and available
+- Ensure that the `distributor`, `ingester`, and `index-gateway` components are ready and available
+- Ensure that store services (`ingester`, `querier`, `index-gateway`, `compactor`) can communicate with backend storage
+- Examine metrics for signs of failure
+  - WAL Complications
+    - `loki_ingester_wal_disk_full_failures_total`
+    - `loki_ingester_wal_corruptions_total`
+
+## LokiStack Read Request Errors
+
+### Impact
+
+The LokiStack Gateway component is unable to perform its duties for a number of query requests, resulting in a potential disruption.
+
+### Summary
+
+The LokiStack Gateway is failing to process at least 10% of all incoming query requests.
+
+### Severity
+
+`Critical`
+
+### Access Required
+
+- Console access to the cluster
+- Edit access to the deployed operator and Loki namespace:
+  - OpenShift
+    - `openshift-logging` (LokiStack)
+    - `openshift-operators-redhat` (Loki Operator)
+
+### Steps
+
+- Ensure that the LokiStack Gateway component is ready and available
+- Ensure that the `query-frontend`, `querier`, `ingester`, and `index-gateway` components are ready and available
+- Ensure that store services (`ingester`, `querier`, `index-gateway`, `compactor`) can communicate with backend storage
+- Examine metrics for signs of failure
+  - WAL Complications
+    - `loki_ingester_wal_disk_full_failures_total`
+    - `loki_ingester_wal_corruptions_total`
 
 ## Loki Request Panics
 
@@ -66,8 +129,8 @@ A service(s) has crashed.
 - Console access to the cluster
 - Edit access to the deployed operator and Loki namespace:
   - OpenShift
-    - `openshift-logging`
-    - `openshift-operators-redhat`
+    - `openshift-logging` (LokiStack)
+    - `openshift-operators-redhat` (Loki Operator)
 
 ### Steps
 

--- a/operator/hack/addons_dev.yaml
+++ b/operator/hack/addons_dev.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.6.1
+          image: docker.io/grafana/logcli:2.6.1-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/operator/hack/addons_ocp.yaml
+++ b/operator/hack/addons_ocp.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.6.1
+          image: docker.io/grafana/logcli:2.6.1-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/operator/internal/manifests/build_test.go
+++ b/operator/internal/manifests/build_test.go
@@ -810,6 +810,63 @@ func TestBuildAll_WithFeatureGates_LokiStackAlerts(t *testing.T) {
 	}
 }
 
+func TestBuildAll_WithFeatureGates_DefaultNodeAffinity(t *testing.T) {
+	tt := []struct {
+		desc         string
+		nodeAffinity bool
+		wantAffinity *corev1.Affinity
+	}{
+		{
+			desc:         "disabled",
+			nodeAffinity: false,
+			wantAffinity: nil,
+		},
+		{
+			desc:         "enabled",
+			nodeAffinity: true,
+			wantAffinity: defaultAffinity(true),
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			opts := &Options{
+				Name:      "test",
+				Namespace: "test",
+				Stack: lokiv1.LokiStackSpec{
+					Size: lokiv1.SizeOneXSmall,
+				},
+				Gates: configv1.FeatureGates{
+					DefaultNodeAffinity: tc.nodeAffinity,
+				},
+			}
+
+			err := ApplyDefaultSettings(opts)
+			require.NoError(t, err)
+
+			objects, err := BuildAll(*opts)
+			require.NoError(t, err)
+
+			for _, raw := range objects {
+				gotAffinity, skip, err := extractAffinity(raw)
+				require.NoError(t, err)
+
+				if skip {
+					// Object with no affinity
+					continue
+				}
+
+				require.Equal(t, tc.wantAffinity, gotAffinity,
+					"kind", raw.GetObjectKind().GroupVersionKind(),
+					"name", raw.GetName())
+			}
+		})
+	}
+}
+
 func serviceMonitorCount(objects []client.Object) int {
 	monitors := 0
 	for _, obj := range objects {
@@ -828,4 +885,18 @@ func checkGatewayDeployed(objects []client.Object, stackName string) bool {
 		}
 	}
 	return false
+}
+
+func extractAffinity(raw client.Object) (*corev1.Affinity, bool, error) {
+	switch obj := raw.(type) {
+	case *appsv1.Deployment:
+		return obj.Spec.Template.Spec.Affinity, false, nil
+	case *appsv1.StatefulSet:
+		return obj.Spec.Template.Spec.Affinity, false, nil
+	case *corev1.ConfigMap, *corev1.Service:
+		return nil, true, nil
+	default:
+	}
+
+	return nil, false, fmt.Errorf("unknown kind: %s", raw.GetObjectKind().GroupVersionKind())
 }

--- a/operator/internal/manifests/compactor.go
+++ b/operator/internal/manifests/compactor.go
@@ -46,6 +46,7 @@ func BuildCompactor(opts Options) ([]client.Object, error) {
 // NewCompactorStatefulSet creates a statefulset object for a compactor.
 func NewCompactorStatefulSet(opts Options) *appsv1.StatefulSet {
 	podSpec := corev1.PodSpec{
+		Affinity: defaultAffinity(opts.Gates.DefaultNodeAffinity),
 		Volumes: []corev1.Volume{
 			{
 				Name: configVolumeName,

--- a/operator/internal/manifests/distributor.go
+++ b/operator/internal/manifests/distributor.go
@@ -41,6 +41,7 @@ func BuildDistributor(opts Options) ([]client.Object, error) {
 // NewDistributorDeployment creates a deployment object for a distributor
 func NewDistributorDeployment(opts Options) *appsv1.Deployment {
 	podSpec := corev1.PodSpec{
+		Affinity: defaultAffinity(opts.Gates.DefaultNodeAffinity),
 		Volumes: []corev1.Volume{
 			{
 				Name: configVolumeName,

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -69,6 +69,7 @@ func BuildGateway(opts Options) ([]client.Object, error) {
 // NewGatewayDeployment creates a deployment object for a lokiStack-gateway
 func NewGatewayDeployment(opts Options, sha1C string) *appsv1.Deployment {
 	podSpec := corev1.PodSpec{
+		Affinity: defaultAffinity(opts.Gates.DefaultNodeAffinity),
 		Volumes: []corev1.Volume{
 			{
 				Name: "rbac",

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -292,6 +292,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Args: []string{
 										"--log.level=warn",
 										"--tls.min-version=VersionTLS12",
+										"--opa.skip-tenants=audit,infrastructure",
+										"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
 										"--opa.package=lokistack",
 										"--opa.matcher=kubernetes_namespace_name",
 										"--web.listen=:8082",
@@ -466,6 +468,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Args: []string{
 										"--log.level=warn",
 										"--tls.min-version=VersionTLS12",
+										"--opa.skip-tenants=audit,infrastructure",
+										"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
 										"--opa.package=lokistack",
 										"--opa.matcher=kubernetes_namespace_name",
 										"--web.listen=:8082",
@@ -658,6 +662,8 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 									Args: []string{
 										"--log.level=warn",
 										"--tls.min-version=VersionTLS12",
+										"--opa.skip-tenants=audit,infrastructure",
+										"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
 										"--opa.package=lokistack",
 										"--opa.matcher=kubernetes_namespace_name",
 										"--web.listen=:8082",

--- a/operator/internal/manifests/indexgateway.go
+++ b/operator/internal/manifests/indexgateway.go
@@ -45,6 +45,7 @@ func BuildIndexGateway(opts Options) ([]client.Object, error) {
 // NewIndexGatewayStatefulSet creates a statefulset object for an index-gateway
 func NewIndexGatewayStatefulSet(opts Options) *appsv1.StatefulSet {
 	podSpec := corev1.PodSpec{
+		Affinity: defaultAffinity(opts.Gates.DefaultNodeAffinity),
 		Volumes: []corev1.Volume{
 			{
 				Name: configVolumeName,

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -49,6 +49,7 @@ func BuildIngester(opts Options) ([]client.Object, error) {
 // NewIngesterStatefulSet creates a deployment object for an ingester
 func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 	podSpec := corev1.PodSpec{
+		Affinity: defaultAffinity(opts.Gates.DefaultNodeAffinity),
 		Volumes: []corev1.Volume{
 			{
 				Name: configVolumeName,

--- a/operator/internal/manifests/internal/alerts/build.go
+++ b/operator/internal/manifests/internal/alerts/build.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// RunbookDefaultURL is the default url for the documentation of the Prometheus alerts
-	RunbookDefaultURL = "https://github.com/grafana/loki/tree/main/operator/docs/alerts.md"
+	RunbookDefaultURL = "https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md"
 )
 
 var (

--- a/operator/internal/manifests/internal/alerts/prometheus-alerts.yaml
+++ b/operator/internal/manifests/internal/alerts/prometheus-alerts.yaml
@@ -10,16 +10,62 @@ groups:
       runbook_url: "[[ .RunbookURL ]]#Loki-Request-Errors"
     expr: |
       sum(
-          rate(
-              loki_request_duration_seconds_count{status_code=~"5.."}[1m]
-          )
+        rate(
+          loki_request_duration_seconds_count{status_code=~"5.."}[1m]
+        )
       ) by (namespace, job, route)
       /
       sum(
-          rate(
-              loki_request_duration_seconds_count[1m]
-          )
+        rate(
+          loki_request_duration_seconds_count[1m]
+        )
       ) by (namespace, job, route)
+      * 100
+      > 10
+    for: 15m
+    labels:
+      severity: critical
+  - alert: LokiStackWriteRequestErrors
+    annotations:
+      message: |-
+        {{ printf "%.2f" $value }}% of write requests from {{ $labels.job }} are returned with server errors.
+      summary: "At least 10% of write requests to the lokistack-gateway are responded with 5xx server errors."
+      runbook_url: "[[ .RunbookURL ]]#LokiStack-Write-Request-Errors"
+    expr: |
+      sum(
+        rate(
+          http_requests_total{code=~"5..", group="logsv1", handler="push"}[1m]
+        )
+      ) by (namespace, job, tenant)
+      /
+      sum(
+        rate(
+          http_requests_total{group="logsv1", handler="push"}[1m]
+        )
+      ) by (namespace, job, tenant)
+      * 100
+      > 10
+    for: 15m
+    labels:
+      severity: critical
+  - alert: LokiStackReadRequestErrors
+    annotations:
+      message: |-
+        {{ printf "%.2f" $value }}% of query requests from {{ $labels.job }} are returned with server errors.
+      summary: "At least 10% of query requests to the lokistack-gateway are responded with 5xx server errors."
+      runbook_url: "[[ .RunbookURL ]]#LokiStack-Read-Request-Errors"
+    expr: |
+      sum(
+        rate(
+          http_requests_total{code=~"5..", group="logsv1", handler=~"query|query_range|label|labels|label_values"}[1m]
+        )
+      ) by (namespace, job, tenant)
+      /
+      sum(
+        rate(
+          http_requests_total{group="logsv1", handler=~"query|query_range|label|labels|label_values"}[1m]
+        )
+      ) by (namespace, job, tenant)
       * 100
       > 10
     for: 15m
@@ -33,9 +79,9 @@ groups:
       runbook_url: "[[ .RunbookURL ]]#Loki-Request-Panics"
     expr: |
       sum(
-          increase(
-              loki_panic_total[10m]
-          )
+        increase(
+          loki_panic_total[10m]
+        )
       ) by (namespace, job)
       > 0
     labels:

--- a/operator/internal/manifests/internal/alerts/testdata/test.yaml
+++ b/operator/internal/manifests/internal/alerts/testdata/test.yaml
@@ -11,13 +11,20 @@ tests:
         values: '1+1x20'
       - series: 'loki_request_duration_seconds_count{status_code="200", namespace="my-ns", job="ingester", route="my-route"}'
         values: '1+3x20'
+      - series: 'http_requests_total{code="500", namespace="my-ns", job="gateway", handler="push", group="logsv1"}'
+        values: '1+1x20'
+      - series: 'http_requests_total{code="200", namespace="my-ns", job="gateway", handler="push", group="logsv1"}'
+        values: '1+3x20'
+      - series: 'http_requests_total{code="500", namespace="my-ns", job="gateway", handler="query", group="logsv1"}'
+        values: '1+1x20'
+      - series: 'http_requests_total{code="200", namespace="my-ns", job="gateway", handler="query", group="logsv1"}'
+        values: '1+3x20'
 
       - series: 'loki_panic_total{namespace="my-ns", job="ingester"}'
         values: '0 1 1 2+0x10'
 
     # Unit test for alerting rules.
     alert_rule_test:
-      # --------- LokiRequestErrors ---------
       - eval_time: 16m
         alertname: LokiRequestErrors
         exp_alerts:
@@ -30,8 +37,28 @@ tests:
               summary: "At least 10% of requests are responded by 5xx server errors."
               message: "ingester my-route is experiencing 25.00% errors."
               runbook_url: "[[ .RunbookURL ]]#Loki-Request-Errors"
-
-      # --------- LokiRequestPanics ---------
+      - eval_time: 16m
+        alertname: LokiStackWriteRequestErrors
+        exp_alerts:
+          - exp_labels:
+              namespace: my-ns
+              job: gateway
+              severity: critical
+            exp_annotations:
+              summary: "At least 10% of write requests to the lokistack-gateway are responded with 5xx server errors."
+              message: "25.00% of write requests from gateway are returned with server errors."
+              runbook_url: "[[ .RunbookURL ]]#LokiStack-Write-Request-Errors"
+      - eval_time: 16m
+        alertname: LokiStackReadRequestErrors
+        exp_alerts:
+          - exp_labels:
+              namespace: my-ns
+              job: gateway
+              severity: critical
+            exp_annotations:
+              summary: "At least 10% of query requests to the lokistack-gateway are responded with 5xx server errors."
+              message: "25.00% of query requests from gateway are returned with server errors."
+              runbook_url: "[[ .RunbookURL ]]#LokiStack-Read-Request-Errors"
       - eval_time: 10m
         alertname: LokiRequestPanics
         exp_alerts:

--- a/operator/internal/manifests/openshift/opa_openshift.go
+++ b/operator/internal/manifests/openshift/opa_openshift.go
@@ -36,6 +36,8 @@ func newOPAOpenShiftContainer(secretVolumeName, tlsDir, certFile, keyFile string
 	args = []string{
 		"--log.level=warn",
 		"--tls.min-version=VersionTLS12",
+		"--opa.skip-tenants=audit,infrastructure",
+		"--opa.admin-groups=system:cluster-admins,cluster-admin,dedicated-admin",
 		fmt.Sprintf("--opa.package=%s", opaDefaultPackage),
 		fmt.Sprintf("--opa.matcher=%s", opaDefaultLabelMatcher),
 		fmt.Sprintf("--web.listen=:%d", GatewayOPAHTTPPort),

--- a/operator/internal/manifests/querier.go
+++ b/operator/internal/manifests/querier.go
@@ -47,6 +47,7 @@ func BuildQuerier(opts Options) ([]client.Object, error) {
 // NewQuerierDeployment creates a deployment object for a querier
 func NewQuerierDeployment(opts Options) *appsv1.Deployment {
 	podSpec := corev1.PodSpec{
+		Affinity: defaultAffinity(opts.Gates.DefaultNodeAffinity),
 		Volumes: []corev1.Volume{
 			{
 				Name: configVolumeName,

--- a/operator/internal/manifests/query-frontend.go
+++ b/operator/internal/manifests/query-frontend.go
@@ -41,6 +41,7 @@ func BuildQueryFrontend(opts Options) ([]client.Object, error) {
 // NewQueryFrontendDeployment creates a deployment object for a query-frontend
 func NewQueryFrontendDeployment(opts Options) *appsv1.Deployment {
 	podSpec := corev1.PodSpec{
+		Affinity: defaultAffinity(opts.Gates.DefaultNodeAffinity),
 		Volumes: []corev1.Volume{
 			{
 				Name: configVolumeName,

--- a/operator/internal/manifests/ruler.go
+++ b/operator/internal/manifests/ruler.go
@@ -39,9 +39,10 @@ func BuildRuler(opts Options) ([]client.Object, error) {
 	}, nil
 }
 
-// NewRulerStatefulSet creates a statefulset object for an ruler
+// NewRulerStatefulSet creates a statefulset object for a ruler
 func NewRulerStatefulSet(opts Options) *appsv1.StatefulSet {
 	podSpec := corev1.PodSpec{
+		Affinity: defaultAffinity(opts.Gates.DefaultNodeAffinity),
 		Volumes: []corev1.Volume{
 			{
 				Name: configVolumeName,

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -90,6 +90,9 @@ const (
 	caBundleDir = "/var/run/ca"
 	// caFile is the file name of the certificate authority file
 	caFile = "service-ca.crt"
+
+	kubernetesNodeOSLabel = "kubernetes.io/os"
+	kubernetesNodeOSLinux = "linux"
 )
 
 var (
@@ -296,6 +299,32 @@ func serviceMonitorEndpoint(portName, serviceName, namespace string, enableTLS b
 		Port:   portName,
 		Path:   "/metrics",
 		Scheme: "http",
+	}
+}
+
+func defaultAffinity(enableNodeAffinity bool) *corev1.Affinity {
+	if !enableNodeAffinity {
+		return nil
+	}
+
+	return &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      kubernetesNodeOSLabel,
+								Operator: corev1.NodeSelectorOpIn,
+								Values: []string{
+									kubernetesNodeOSLinux,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
# Summary

The following PR backports all bugfixes introduced for `release-5.5` since `5.5.0` till today. The following upstream PRs are included:

- grafana/loki#6935
- grafana/loki#6997
- grafana/loki#6999
- grafana/loki#7000