### PR TITLE
[release-5.5] Backport PR grafana/loki#7214

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Main
 
+- [7214](https://github.com/grafana/loki/pull/7214) **periklis**: Fix ruler GRPC tls client configuration
 - [7037](https://github.com/grafana/loki/pull/7037) **xperimental**: Skip enforcing matcher for certain tenants on OpenShift
-- [7106](https://github.com/grafana/loki/pull/7106) **xperimental**: Manage global stream-based retention
 - [7092](https://github.com/grafana/loki/pull/7092) **aminesnow**: Configure kube-rbac-proxy sidecar to use Intermediate TLS security profile in OCP
 - [6870](https://github.com/grafana/loki/pull/6870) **aminesnow**: Configure gateway to honor the global tlsSecurityProfile on Openshift
 - [6999](https://github.com/grafana/loki/pull/6999) **Red-GV**: Adding LokiStack Gateway alerts


### PR DESCRIPTION
# Summary

The present PR is a backport of the rule TLS client configuration for the ruler

Ref: None

/cc @xperimental
/assign @periklis
