### PR TITLE
LOG-3120: fix skip range for 5.6.0

### DIFF
--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -159,7 +159,7 @@ metadata:
       Loki is a memory intensive application.  The initial
       set of OCP nodes may not be large enough to support the Loki stack.  Additional OCP nodes must be added
       to the OCP cluster if you desire to run with the recommended (or better) memory.
-    olm.skipRange: '>=5.4.0-0 <5.5.0'
+    olm.skipRange: '>=5.4.0-0 <5.6.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift


### PR DESCRIPTION
This PR:
fixes the skip range for logging 5.6.0

ref: https://issues.redhat.com/browse/LOG-3120