### PR TITLE
[release-5.5] Backport PR grafana/loki#7296

### DIFF
--- a/operator/bundle/metadata/properties.yaml
+++ b/operator/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.11
+    value: 4.12


### PR DESCRIPTION
## Description 

The present PR backports the capability to enable release-5.5 subscriptions on OpenShift 4.12

Ref: [LOG-3119](https://issues.redhat.com//browse/LOG-3119)

/cc @xperimental
/assign @periklis