### PR TITLE
Bump base images to Golang 1.19 and OCP 4.12

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,17 +1,17 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
-ARG GOARCH="amd64"
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/grafana/loki
 COPY . .
 RUN touch loki-build-image/.uptodate && mkdir /build
 RUN make clean && make BUILD_IN_CONTAINER=false loki
 
-FROM  registry.ci.openshift.org/ocp/4.10:base
+FROM  registry.ci.openshift.org/ocp/4.12:base
 LABEL io.k8s.display-name="OpenShift Loki" \
       io.k8s.description="Horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus." \
       io.openshift.tags="grafana,prometheus,monitoring" \
       maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
-      version="v2.4.2"
+      version="v2.7.0"
 
 COPY --from=builder /go/src/github.com/grafana/loki/cmd/loki/loki /usr/bin/loki
-COPY --from=builder /go/src/github.com/grafana/loki/cmd/loki/loki-local-config.yaml /etc/loki/local-config.yaml
+COPY --from=builder /go/src/github.com/grafana/loki/cmd/loki/loki-docker-config.yaml /etc/loki/local-config.yaml
 ENTRYPOINT ["/usr/bin/loki"]
+CMD ["-config.file=/etc/loki/local-config.yaml"]

--- a/Dockerfile.promtail.ocp
+++ b/Dockerfile.promtail.ocp
@@ -1,19 +1,17 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
-ARG GOARCH="amd64"
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/grafana/loki
 COPY . .
 RUN touch loki-build-image/.uptodate && mkdir /build
 RUN make clean && make BUILD_IN_CONTAINER=false promtail
 
-FROM  registry.ci.openshift.org/ocp/4.10:base
+FROM  registry.ci.openshift.org/ocp/4.12:base
 LABEL io.k8s.display-name="OpenShift Loki Promtail" \
       io.k8s.description="An agent responsible for gathering logs and sending them to Loki." \
       io.openshift.tags="grafana,prometheus,monitoring" \
       maintainer="OpenShift Development <dev@lists.openshift.redhat.com>" \
-      version="v2.4.2"
+      version="v2.7.0"
 
 COPY --from=builder /go/src/github.com/grafana/loki/clients/cmd/promtail/promtail /usr/bin/promtail
-COPY --from=builder /go/src/github.com/grafana/loki/clients/cmd/promtail/promtail-local-config.yaml \
-                    /go/src/github.com/grafana/loki/clients/cmd/promtail/promtail-docker-config.yaml \
-                    /etc/promtail/
+COPY --from=builder /go/src/github.com/grafana/loki/clients/cmd/promtail/promtail-docker-config.yaml /etc/promtail/config.yml
 ENTRYPOINT ["/usr/bin/promtail"]
+CMD ["-config.file=/etc/promtail/config.yml"]


### PR DESCRIPTION
Preparation work to address build failures in: 
- #58