### PR TITLE
[release-5.5] LOG-3251: Add valid subscription annotation to metadata

### DIFF
--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -162,6 +162,8 @@ metadata:
     olm.skipRange: '>=5.4.0-0 <5.5.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     support: AOS Cluster Logging

--- a/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
@@ -19,6 +19,8 @@ metadata:
     olm.skipRange: '>=5.4.0-0 <5.5.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift
+      Platform Plus"]'
     support: AOS Cluster Logging
   labels:
     operatorframework.io/arch.amd64: supported


### PR DESCRIPTION
(cherry picked from commit 3d2aa76349471fe528d51939cd669e0446f5db2d)

**What this PR does / why we need it**:
This PR adds the operators.openshift.io/valid-subscription annotation to the operator metadata.

**Which issue(s) this PR fixes**:

https://issues.redhat.com/browse/LOG-3251

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the `CONTRIBUTING.md` guide
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
