### PR TITLE
release-5.5] Backport PR grafana/loki#7910

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [7910](https://github.com/grafana/loki/pull/7910) **periklis**: Update Loki operand to v2.7.1
 - [7815](https://github.com/grafana/loki/pull/7815) **periklis**: Apply delete client changes for compat with release-2.7.x
 - [7809](https://github.com/grafana/loki/pull/7809) **xperimental**: Fix histogram-based alerting rules
 - [7808](https://github.com/grafana/loki/pull/7808) **xperimental**: Replace fifocache usage by embedded_cache

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1260,7 +1260,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: quay.io/openshift-logging/loki:v2.7.0-pre
+                  value: quay.io/openshift-logging/loki:v2.7.1
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1388,7 +1388,7 @@ spec:
   provider:
     name: Grafana.com
   relatedImages:
-  - image: quay.io/openshift-logging/loki:v2.7.0-pre
+  - image: quay.io/openshift-logging/loki:v2.7.1
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/config/overlays/development/manager_related_image_patch.yaml
+++ b/operator/config/overlays/development/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:k120-26d2989
+            value: docker.io/grafana/loki:2.7.1
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/config/overlays/openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: quay.io/openshift-logging/loki:v2.7.0-pre
+            value: quay.io/openshift-logging/loki:v2.7.1
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/config/overlays/production/manager_related_image_patch.yaml
+++ b/operator/config/overlays/production/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:main-ec0bf70
+            value: docker.io/grafana/loki:2.7.1
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/docs/operator/compatibility.md
+++ b/operator/docs/operator/compatibility.md
@@ -27,5 +27,4 @@ Due to the use of apiextensions.k8s.io/v1 CustomResourceDefinitions, requires Ku
 
 The versions of Loki compatible to be run with the Loki Operator are:
 
-* v2.6.0
-* v2.6.1
+* v2.7.1

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -99,14 +99,14 @@ func ConfigOptions(opt Options) config.Options {
 			},
 			ServerNames: config.TLSServerNames{
 				GRPC: config.GRPCServerNames{
+					Compactor:     fqdn(serviceNameCompactorGRPC(opt.Name), opt.Namespace),
 					IndexGateway:  fqdn(serviceNameIndexGatewayGRPC(opt.Name), opt.Namespace),
 					Ingester:      fqdn(serviceNameIngesterGRPC(opt.Name), opt.Namespace),
 					QueryFrontend: fqdn(serviceNameQueryFrontendGRPC(opt.Name), opt.Namespace),
 					Ruler:         fqdn(serviceNameRulerGRPC(opt.Name), opt.Namespace),
 				},
 				HTTP: config.HTTPServerNames{
-					Compactor: fqdn(serviceNameCompactorHTTP(opt.Name), opt.Namespace),
-					Querier:   fqdn(serviceNameQuerierHTTP(opt.Name), opt.Namespace),
+					Querier: fqdn(serviceNameQuerierHTTP(opt.Name), opt.Namespace),
 				},
 			},
 		},

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -2440,12 +2440,12 @@ querier:
   max_concurrent: 2
   query_ingesters_within: 3h
   tail_max_duration: 1h
-delete_client:
+compactor_grpc_client:
   tls_enabled: true
-  tls_cert_path: /var/run/tls/http/tls.crt
-  tls_key_path: /var/run/tls/http/tls.key
+  tls_cert_path: /var/run/tls/grpc/tls.crt
+  tls_key_path: /var/run/tls/grpc/tls.key
   tls_ca_path: /var/run/tls/ca.pem
-  tls_server_name: compactor-http.svc
+  tls_server_name: compactor-grpc.svc
   tls_cipher_suites: cipher1,cipher2
   tls_min_version: VersionTLS12
 query_range:
@@ -2568,14 +2568,14 @@ overrides:
 			},
 			ServerNames: TLSServerNames{
 				GRPC: GRPCServerNames{
+					Compactor:     "compactor-grpc.svc",
 					IndexGateway:  "index-gateway-grpc.svc",
 					Ingester:      "ingester-grpc.svc",
 					QueryFrontend: "query-frontend-grpc.svc",
 					Ruler:         "ruler-grpc.svc",
 				},
 				HTTP: HTTPServerNames{
-					Compactor: "compactor-http.svc",
-					Querier:   "querier-http.svc",
+					Querier: "querier-http.svc",
 				},
 			},
 		},

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -180,13 +180,13 @@ querier:
   query_ingesters_within: 3h
   tail_max_duration: 1h
   max_concurrent: {{ .MaxConcurrent.AvailableQuerierCPUCores }}
-{{- if .Gates.HTTPEncryption }}
-delete_client:
+{{- if .Gates.GRPCEncryption }}
+compactor_grpc_client:
   tls_enabled: true
-  tls_cert_path: {{ .TLS.Paths.HTTP.Certificate }}
-  tls_key_path: {{ .TLS.Paths.HTTP.Key }}
+  tls_cert_path: {{ .TLS.Paths.GRPC.Certificate }}
+  tls_key_path: {{ .TLS.Paths.GRPC.Key }}
   tls_ca_path: {{ .TLS.Paths.CA }}
-  tls_server_name: {{ .TLS.ServerNames.HTTP.Compactor }}
+  tls_server_name: {{ .TLS.ServerNames.GRPC.Compactor }}
   tls_cipher_suites: {{ .TLS.CipherSuitesString }}
   tls_min_version: {{ .TLS.MinTLSVersion }}
 {{- end }}

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -198,6 +198,7 @@ type TLSServerNames struct {
 }
 
 type GRPCServerNames struct {
+	Compactor     string
 	IndexGateway  string
 	Ingester      string
 	QueryFrontend string
@@ -205,6 +206,5 @@ type GRPCServerNames struct {
 }
 
 type HTTPServerNames struct {
-	Compactor string
-	Querier   string
+	Querier string
 }

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -52,7 +52,7 @@ const (
 	EnvRelatedImageGateway = "RELATED_IMAGE_GATEWAY"
 
 	// DefaultContainerImage declares the default fallback for loki image.
-	DefaultContainerImage = "docker.io/grafana/loki:2.6.1"
+	DefaultContainerImage = "docker.io/grafana/loki:2.7.1"
 
 	// DefaultLokiStackGatewayImage declares the default image for lokiStack-gateway.
 	DefaultLokiStackGatewayImage = "quay.io/observatorium/api:latest"


### PR DESCRIPTION
The present PR is a backport of the upgrade of the Loki operand to v2.7.1.

Ref: LOG-3285

/cc @xperimental
/assign @periklis