### PR TITLE
[release-5.5] Remove custom webhook cert mounts for OLM-based deployment (#8173)

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8173](https://github.com/grafana/loki/pull/8173) **periklis**: Remove custom webhook cert mounts for OLM-based deployment (OpenShift)
 - [8068](https://github.com/grafana/loki/pull/8068) **periklis**: Use lokistack-gateway replicas from size table
 - [7753](https://github.com/grafana/loki/pull/7753) **periklis**: Check for mandatory CA configmap name in ObjectStorageTLS spec
 - [7744](https://github.com/grafana/loki/pull/7744) **periklis**: Fix object storage TLS spec CAKey descriptor

--- a/operator/bundle/manifests/loki-operator-webhook-service_v1_service.yaml
+++ b/operator/bundle/manifests/loki-operator-webhook-service_v1_service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: loki-operator-webhook-service
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: loki-operator-v0.0.1

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1221,9 +1221,6 @@ spec:
                     drop:
                     - ALL
                 volumeMounts:
-                - mountPath: /tmp/k8s-webhook-server/serving-certs
-                  name: webhook-cert
-                  readOnly: true
                 - mountPath: /controller_manager_config.yaml
                   name: manager-config
                   subPath: controller_manager_config.yaml
@@ -1254,10 +1251,6 @@ spec:
                 runAsNonRoot: true
               terminationGracePeriodSeconds: 10
               volumes:
-              - name: webhook-cert
-                secret:
-                  defaultMode: 420
-                  secretName: loki-operator-webhook-service
               - configMap:
                   name: loki-operator-manager-config
                 name: manager-config

--- a/operator/config/overlays/openshift/kustomization.yaml
+++ b/operator/config/overlays/openshift/kustomization.yaml
@@ -40,7 +40,6 @@ patchesStrategicMerge:
 - manager_run_flags_patch.yaml
 - manager_webhook_patch.yaml
 - prometheus_service_monitor_patch.yaml
-- webhook_service_annotations_patch.yaml
 
 images:
 - name: controller

--- a/operator/config/overlays/openshift/manager_webhook_patch.yaml
+++ b/operator/config/overlays/openshift/manager_webhook_patch.yaml
@@ -11,12 +11,3 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: webhook-cert
-          readOnly: true
-      volumes:
-      - name: webhook-cert
-        secret:
-          defaultMode: 420
-          secretName: loki-operator-webhook-service

--- a/operator/config/overlays/openshift/webhook_service_annotations_patch.yaml
+++ b/operator/config/overlays/openshift/webhook_service_annotations_patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Service
-metadata:
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: loki-operator-webhook-service
-  name: webhook-service
-  namespace: system


### PR DESCRIPTION
Backport of https://github.com/grafana/loki/pull/8173 into release-5.5.

Refs: [LOG-3511](https://issues.redhat.com//browse/LOG-3511)