### PR TITLE
[release-5.6] Backport PR grafana/loki#8265

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8265](https://github.com/grafana/loki/pull/8265) **Red-GV**: Use gRPC compactor service instead of http for retention
 - [8087](https://github.com/grafana/loki/pull/8087) **xperimental**: Fix status not updating when state of pods changes
 - [8173](https://github.com/grafana/loki/pull/8173) **periklis**: Remove custom webhook cert mounts for OLM-based deployment (OpenShift)
 - [8068](https://github.com/grafana/loki/pull/8068) **periklis**: Use lokistack-gateway replicas from size table

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -113,9 +113,8 @@ func ConfigOptions(opt Options) config.Options {
 		Namespace: opt.Namespace,
 		Name:      opt.Name,
 		Compactor: config.Address{
-			FQDN:     fqdn(NewCompactorHTTPService(opt).GetName(), opt.Namespace),
-			Port:     httpPort,
-			Protocol: protocol,
+			FQDN: fqdn(NewCompactorGRPCService(opt).GetName(), opt.Namespace),
+			Port: grpcPort,
 		},
 		FrontendWorker: config.Address{
 			FQDN: fqdn(NewQueryFrontendGRPCService(opt).GetName(), opt.Namespace),

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -27,7 +27,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -193,9 +193,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -264,7 +263,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -447,9 +446,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -522,9 +520,8 @@ func TestBuild_ConfigAndRuntimeConfig_CreateLokiConfigFailed(t *testing.T) {
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -592,7 +589,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -812,9 +809,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -930,7 +926,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -1150,9 +1146,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -1269,7 +1264,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -1502,9 +1497,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -1638,7 +1632,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -1871,9 +1865,8 @@ overrides:
 			Port: 9095,
 		},
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		StorageDirectory: "/tmp/loki",
 		MaxConcurrent: MaxConcurrent{
@@ -1928,7 +1921,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -2174,9 +2167,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
@@ -2327,7 +2319,7 @@ common:
       access_key_id: test
       secret_access_key: test123
       s3forcepathstyle: true
-  compactor_address: http://loki-compactor-http-lokistack-dev.default.svc.cluster.local:3100
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
 compactor:
   compaction_interval: 2h
   working_directory: /tmp/loki/compactor
@@ -2582,9 +2574,8 @@ overrides:
 		Namespace: "test-ns",
 		Name:      "test",
 		Compactor: Address{
-			FQDN:     "loki-compactor-http-lokistack-dev.default.svc.cluster.local",
-			Port:     3100,
-			Protocol: "http",
+			FQDN:     "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port:     9095,
 		},
 		FrontendWorker: Address{
 			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -45,7 +45,7 @@ common:
       region_name: {{ .Region }}
       container_name: {{ .Container }}
     {{- end }}
-  compactor_address: {{ .Compactor.Protocol }}://{{ .Compactor.FQDN }}:{{ .Compactor.Port }}
+  compactor_grpc_address: {{ .Compactor.FQDN }}:{{ .Compactor.Port }}
 compactor:
   compaction_interval: 2h
   working_directory: {{ .StorageDirectory }}/compactor


### PR DESCRIPTION
This PR backports a change which allows the compactor to use gRPC instead of http for the delete requests.

Ref: https://issues.redhat.com/browse/LOG-3494

/cc @xperimental 
/assign @periklis 
