### PR TITLE
[release-5.6] Backport PR grafana/loki#8771

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [8771](https://github.com/grafana/loki/pull/8771) **periklis**: Update Loki operand to v2.7.4
 - [8577](https://github.com/grafana/loki/pull/8577) **Red-GV**: Store gateway tenant information in secret instead of configmap
 - [8397](https://github.com/grafana/loki/pull/8397) **periklis**: Update Loki operand to v2.7.3
 - [8336](https://github.com/grafana/loki/pull/8336) **periklis**: Update Loki operand to v2.7.2

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1260,7 +1260,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: quay.io/openshift-logging/loki:v2.7.3
+                  value: quay.io/openshift-logging/loki:v2.7.4
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1381,7 +1381,7 @@ spec:
   provider:
     name: Grafana.com
   relatedImages:
-  - image: quay.io/openshift-logging/loki:v2.7.3
+  - image: quay.io/openshift-logging/loki:v2.7.4
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/config/overlays/development/manager_related_image_patch.yaml
+++ b/operator/config/overlays/development/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.7.3
+            value: docker.io/grafana/loki:2.7.4
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/config/overlays/openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: quay.io/openshift-logging/loki:v2.7.3
+            value: quay.io/openshift-logging/loki:v2.7.4
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/config/overlays/production/manager_related_image_patch.yaml
+++ b/operator/config/overlays/production/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.7.3
+            value: docker.io/grafana/loki:2.7.4
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/docs/operator/compatibility.md
+++ b/operator/docs/operator/compatibility.md
@@ -30,3 +30,4 @@ The versions of Loki compatible to be run with the Loki Operator are:
 * v2.7.1
 * v2.7.2
 * v2.7.3
+* v2.7.4

--- a/operator/hack/addons_dev.yaml
+++ b/operator/hack/addons_dev.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.6.1-amd64
+          image: docker.io/grafana/logcli:2.7.4-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -73,7 +73,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.6.1
+          image: docker.io/grafana/promtail:2.7.4
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/hack/addons_ocp.yaml
+++ b/operator/hack/addons_ocp.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.6.1-amd64
+          image: docker.io/grafana/logcli:2.7.4-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.6.1
+          image: docker.io/grafana/promtail:2.7.4
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -52,7 +52,7 @@ const (
 	EnvRelatedImageGateway = "RELATED_IMAGE_GATEWAY"
 
 	// DefaultContainerImage declares the default fallback for loki image.
-	DefaultContainerImage = "docker.io/grafana/loki:2.7.3"
+	DefaultContainerImage = "docker.io/grafana/loki:2.7.4"
 
 	// DefaultLokiStackGatewayImage declares the default image for lokiStack-gateway.
 	DefaultLokiStackGatewayImage = "quay.io/observatorium/api:latest"


### PR DESCRIPTION
The present PR is a backport of the Loki operand update from v2.7.3 to v2.7.4.

Ref: [LOG-3660](https://issues.redhat.com//browse/LOG-3660)

/cc @xperimental
/assign @periklis