### PR TITLE
[release-5.6] Backport PR grafana/loki#8707

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Main
 
 - [8771](https://github.com/grafana/loki/pull/8771) **periklis**: Update Loki operand to v2.7.4
+- [8707](https://github.com/grafana/loki/pull/8707) **aminesnow**: Fix gateway's nodeSelector and toleration
 - [8577](https://github.com/grafana/loki/pull/8577) **Red-GV**: Store gateway tenant information in secret instead of configmap
 - [8397](https://github.com/grafana/loki/pull/8397) **periklis**: Update Loki operand to v2.7.3
 - [8336](https://github.com/grafana/loki/pull/8336) **periklis**: Update Loki operand to v2.7.2

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -198,6 +198,11 @@ func NewGatewayDeployment(opts Options, sha1C string) *appsv1.Deployment {
 		},
 	}
 
+	if opts.Stack.Template != nil && opts.Stack.Template.Gateway != nil {
+		podSpec.Tolerations = opts.Stack.Template.Gateway.Tolerations
+		podSpec.NodeSelector = opts.Stack.Template.Gateway.NodeSelector
+	}
+
 	l := ComponentLabels(LabelGatewayComponent, opts.Name)
 	a := commonAnnotations(sha1C, opts.CertRotationRequiredAt)
 

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -54,6 +54,51 @@ func TestNewGatewayDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
 	require.Equal(t, annotations[expected], sha1C)
 }
 
+func TestNewGatewayDeployment_HasNodeSelector(t *testing.T) {
+	toleration := []corev1.Toleration{
+		{
+			Key:      "foo",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "bar",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+	selector := map[string]string{
+		"foo": "bar",
+	}
+	dpl := NewGatewayDeployment(Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Stack: lokiv1.LokiStackSpec{
+			Template: &lokiv1.LokiTemplateSpec{
+				Compactor: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+				Distributor: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+				Gateway: &lokiv1.LokiComponentSpec{
+					Replicas:     rand.Int31(),
+					NodeSelector: selector,
+					Tolerations:  toleration,
+				},
+				Ingester: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+				Querier: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+				QueryFrontend: &lokiv1.LokiComponentSpec{
+					Replicas: rand.Int31(),
+				},
+			},
+		},
+	}, "deadbeef")
+
+	require.Equal(t, dpl.Spec.Template.Spec.NodeSelector, selector)
+	require.ElementsMatch(t, dpl.Spec.Template.Spec.Tolerations, toleration)
+}
+
 func TestNewGatewayDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
 	sha1C := "deadbeef"
 	ss := NewGatewayDeployment(Options{


### PR DESCRIPTION
The present PR is a backport of the fix that applies tolerations and nodeselector to the lokistack-gateway deployment.

Ref: [LOG-3783](https://issues.redhat.com//browse/LOG-3783)

/cc @xperimental @aminesnow 
/assign @periklis