### PR TITLE
[release-5.6] Backport PR grafana/loki#8958

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Main
 
+## Release 5.6.5
+
+- [8958](https://github.com/grafana/loki/pull/8958) **periklis**: Align common instance addr with memberlist advertise addr
+
+## Release 5.6.4
+
 - [8672](https://github.com/grafana/loki/pull/8672) **periklis**: Add support for memberlist bind network configuration
 - [8771](https://github.com/grafana/loki/pull/8771) **periklis**: Update Loki operand to v2.7.4
 - [8707](https://github.com/grafana/loki/pull/8707) **aminesnow**: Fix gateway's nodeSelector and toleration

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -109,6 +109,7 @@ limits_config:
   query_timeout: 1m
 memberlist:
   abort_if_cluster_join_fails: true
+  advertise_port: 7946
   bind_port: 7946
   join_members:
     - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
@@ -350,6 +351,7 @@ limits_config:
   query_timeout: 1m
 memberlist:
   abort_if_cluster_join_fails: true
+  advertise_port: 7946
   bind_port: 7946
   join_members:
     - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
@@ -682,6 +684,7 @@ limits_config:
   query_timeout: 1m
 memberlist:
   abort_if_cluster_join_fails: true
+  advertise_port: 7946
   bind_port: 7946
   join_members:
     - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
@@ -1024,6 +1027,7 @@ limits_config:
   query_timeout: 1m
 memberlist:
   abort_if_cluster_join_fails: true
+  advertise_port: 7946
   bind_port: 7946
   join_members:
     - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
@@ -1367,6 +1371,7 @@ limits_config:
   query_timeout: 1m
 memberlist:
   abort_if_cluster_join_fails: true
+  advertise_port: 7946
   bind_port: 7946
   join_members:
     - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
@@ -1748,6 +1753,7 @@ limits_config:
   query_timeout: 1m
 memberlist:
   abort_if_cluster_join_fails: true
+  advertise_port: 7946
   bind_port: 7946
   join_members:
     - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
@@ -2034,6 +2040,7 @@ limits_config:
   query_timeout: 2m
 memberlist:
   abort_if_cluster_join_fails: true
+  advertise_port: 7946
   bind_port: 7946
   join_members:
     - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
@@ -2458,6 +2465,7 @@ limits_config:
   query_timeout: 1m
 memberlist:
   abort_if_cluster_join_fails: true
+  advertise_port: 7946
   bind_port: 7946
   join_members:
     - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
@@ -2768,6 +2776,8 @@ limits_config:
   query_timeout: 1m
 memberlist:
   abort_if_cluster_join_fails: true
+  advertise_addr: ${HASH_RING_INSTANCE_ADDR}
+  advertise_port: 7946
   bind_port: 7946
   join_members:
     - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -176,6 +176,10 @@ limits_config:
 {{- with .GossipRing }}
 memberlist:
   abort_if_cluster_join_fails: true
+  {{- with .InstanceAddr }}
+  advertise_addr: {{ . }}
+  {{- end }}
+  advertise_port: {{ .BindPort }}
   bind_port: {{ .BindPort }}
   join_members:
     - {{ .MembersDiscoveryAddr }}:{{ .BindPort }}


### PR DESCRIPTION
The present PR is a backport into `release-5.6` of:
- grafana/loki#8958

Ref: [LOG-3814](https://issues.redhat.com//browse/LOG-3814)

/cc @xperimental
/assign @periklis
