### PR TITLE
[release-5.6] Backport PR grafana/loki#8978

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.5
 
+- [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret
 - [8958](https://github.com/grafana/loki/pull/8958) **periklis**: Align common instance addr with memberlist advertise addr
 
 ## Release 5.6.4

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -92,6 +92,19 @@ var (
 			return false
 		},
 	})
+	createUpdateOrDeletePred = builder.WithPredicates(predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld.GetGeneration() == 0 && len(e.ObjectOld.GetAnnotations()) == 0 {
+				return e.ObjectOld.GetResourceVersion() != e.ObjectNew.GetResourceVersion()
+			}
+
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() ||
+				cmp.Diff(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations()) != ""
+		},
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	})
 )
 
 // LokiStackReconciler reconciles a LokiStack object
@@ -193,7 +206,8 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 		Owns(&rbacv1.ClusterRole{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.ClusterRoleBinding{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.Role{}, updateOrDeleteOnlyPred).
-		Owns(&rbacv1.RoleBinding{}, updateOrDeleteOnlyPred)
+		Owns(&rbacv1.RoleBinding{}, updateOrDeleteOnlyPred).
+		Watches(&source.Kind{Type: &corev1.Secret{}}, r.enqueueForStorageSecret(), createUpdateOrDeletePred)
 
 	if r.FeatureGates.LokiStackAlerts {
 		bld = bld.Owns(&monitoringv1.PrometheusRule{}, updateOrDeleteOnlyPred)
@@ -236,6 +250,34 @@ func (r *LokiStackReconciler) enqueueAllLokiStacksHandler() handler.EventHandler
 		}
 
 		r.Log.Info("Enqueued requests for all LokiStacks because of global resource change", "count", len(requests), "kind", obj.GetObjectKind())
+		return requests
+	})
+}
+
+func (r *LokiStackReconciler) enqueueForStorageSecret() handler.EventHandler {
+	ctx := context.TODO()
+	return handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+		lokiStacks := &lokiv1.LokiStackList{}
+		if err := r.Client.List(ctx, lokiStacks); err != nil {
+			r.Log.Error(err, "Error getting LokiStack resources in event handler")
+			return nil
+		}
+
+		var requests []reconcile.Request
+		for _, stack := range lokiStacks.Items {
+			if obj.GetName() == stack.Spec.Storage.Secret.Name && obj.GetNamespace() == stack.Namespace {
+				requests = append(requests, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: stack.Namespace,
+						Name:      stack.Name,
+					},
+				})
+				r.Log.Info("Enqueued requests for LokiStack because of Storage Secret resource change", "LokiStack", stack.Name, "Secret", obj.GetName())
+
+				return requests
+			}
+		}
+
 		return requests
 	})
 }

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -202,8 +202,8 @@ func TestLokiStackController_RegisterWatchedResources(t *testing.T) {
 	table := []test{
 		{
 			src:               &source.Kind{Type: &openshiftconfigv1.APIServer{}},
-			index:             0,
-			watchesCallsCount: 1,
+			index:             1,
+			watchesCallsCount: 2,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
 					ClusterTLSPolicy: true,
@@ -213,14 +213,21 @@ func TestLokiStackController_RegisterWatchedResources(t *testing.T) {
 		},
 		{
 			src:               &source.Kind{Type: &openshiftconfigv1.Proxy{}},
-			index:             0,
-			watchesCallsCount: 1,
+			index:             1,
+			watchesCallsCount: 2,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
 					ClusterProxy: true,
 				},
 			},
 			pred: updateOrDeleteOnlyPred,
+		},
+		{
+			src:               &source.Kind{Type: &corev1.Secret{}},
+			index:             0,
+			watchesCallsCount: 1,
+			featureGates:      configv1.FeatureGates{},
+			pred:              createUpdateOrDeletePred,
 		},
 	}
 	for _, tst := range table {

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -57,6 +57,7 @@ func TestLokiStackController_RegistersCustomResourceForCreateOrUpdate(t *testing
 
 	b.ForReturns(b)
 	b.OwnsReturns(b)
+	b.WatchesReturns(b)
 
 	err := c.buildController(b)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR is a backport of #8978, which adds a watch on the object storage secret.

ref: [LOG-3944](https://issues.redhat.com/browse/LOG-3944)
/cc @periklis 