### PR TITLE
[release-5.7] Backport PR grafana/loki#9433

### DIFF
--- a/operator/internal/manifests/compactor_test.go
+++ b/operator/internal/manifests/compactor_test.go
@@ -1,10 +1,9 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +14,7 @@ func TestNewCompactorStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	sts := manifests.NewCompactorStatefulSet(manifests.Options{
+	sts := NewCompactorStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -36,7 +35,7 @@ func TestNewCompactorStatefulSet_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestNewCompactorStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewCompactorStatefulSet(manifests.Options{
+	ss := NewCompactorStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -56,7 +55,7 @@ func TestNewCompactorStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewCompactorStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewCompactorStatefulSet(manifests.Options{
+	ss := NewCompactorStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -1,4 +1,4 @@
-package manifests_test
+package manifests
 
 import (
 	"encoding/json"
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	"github.com/grafana/loki/operator/internal/manifests/openshift"
 	"github.com/stretchr/testify/assert"
@@ -19,17 +18,17 @@ import (
 func TestConfigMap_ReturnsSHA1OfBinaryContents(t *testing.T) {
 	opts := randomConfigOptions()
 
-	_, sha1C, err := manifests.LokiConfigMap(opts)
+	_, sha1C, err := LokiConfigMap(opts)
 	require.NoError(t, err)
 	require.NotEmpty(t, sha1C)
 }
 
 func TestConfigOptions_UserOptionsTakePrecedence(t *testing.T) {
 	// regardless of what is provided by the default sizing parameters we should always prefer
-	// the user-defined values. This creates an all-inclusive manifests.Options and then checks
+	// the user-defined values. This creates an all-inclusive Options and then checks
 	// that every value is present in the result
 	opts := randomConfigOptions()
-	res := manifests.ConfigOptions(opts)
+	res := ConfigOptions(opts)
 
 	expected, err := json.Marshal(opts.Stack)
 	require.NoError(t, err)
@@ -40,8 +39,8 @@ func TestConfigOptions_UserOptionsTakePrecedence(t *testing.T) {
 	assert.JSONEq(t, string(expected), string(actual))
 }
 
-func randomConfigOptions() manifests.Options {
-	return manifests.Options{
+func randomConfigOptions() Options {
+	return Options{
 		Name:      uuid.New().String(),
 		Namespace: uuid.New().String(),
 		Image:     uuid.New().String(),
@@ -249,12 +248,12 @@ func TestConfigOptions_GossipRingConfig(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			inOpt := manifests.Options{
+			inOpt := Options{
 				Name:      "my-stack",
 				Namespace: "my-ns",
 				Stack:     tc.spec,
 			}
-			options := manifests.ConfigOptions(inOpt)
+			options := ConfigOptions(inOpt)
 			require.Equal(t, tc.wantOptions, options.GossipRing)
 		})
 	}
@@ -357,10 +356,10 @@ func TestConfigOptions_RetentionConfig(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			inOpt := manifests.Options{
+			inOpt := Options{
 				Stack: tc.spec,
 			}
-			options := manifests.ConfigOptions(inOpt)
+			options := ConfigOptions(inOpt)
 			require.Equal(t, tc.wantOptions, options.Retention)
 		})
 	}
@@ -369,12 +368,12 @@ func TestConfigOptions_RetentionConfig(t *testing.T) {
 func TestConfigOptions_RulerAlertManager(t *testing.T) {
 	tt := []struct {
 		desc        string
-		opts        manifests.Options
+		opts        Options
 		wantOptions *config.AlertManagerConfig
 	}{
 		{
 			desc: "static mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Static,
@@ -385,7 +384,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 		},
 		{
 			desc: "dynamic mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Dynamic,
@@ -396,7 +395,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 		},
 		{
 			desc: "openshift-logging mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -417,7 +416,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 		},
 		{
 			desc: "openshift-network mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,
@@ -443,8 +442,8 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := manifests.ConfigOptions(tc.opts)
-			err := manifests.ConfigureOptionsForMode(&cfg, tc.opts)
+			cfg := ConfigOptions(tc.opts)
+			err := ConfigureOptionsForMode(&cfg, tc.opts)
 
 			require.Nil(t, err)
 			require.Equal(t, tc.wantOptions, cfg.Ruler.AlertManager)
@@ -455,12 +454,12 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 	tt := []struct {
 		desc        string
-		opts        manifests.Options
+		opts        Options
 		wantOptions *config.AlertManagerConfig
 	}{
 		{
 			desc: "static mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Static,
@@ -471,7 +470,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 		},
 		{
 			desc: "dynamic mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Dynamic,
@@ -482,7 +481,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 		},
 		{
 			desc: "openshift-logging mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -491,7 +490,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
 							EnableV2: false,
@@ -518,7 +517,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 		},
 		{
 			desc: "openshift-network mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,
@@ -527,7 +526,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
 							EnableV2: false,
@@ -559,8 +558,8 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := manifests.ConfigOptions(tc.opts)
-			err := manifests.ConfigureOptionsForMode(&cfg, tc.opts)
+			cfg := ConfigOptions(tc.opts)
+			err := ConfigureOptionsForMode(&cfg, tc.opts)
 			require.Nil(t, err)
 			require.Equal(t, tc.wantOptions, cfg.Ruler.AlertManager)
 		})
@@ -570,12 +569,12 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 	tt := []struct {
 		desc        string
-		opts        manifests.Options
+		opts        Options
 		wantOptions map[string]config.LokiOverrides
 	}{
 		{
 			desc: "static mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Static,
@@ -586,7 +585,7 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 		},
 		{
 			desc: "dynamic mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Dynamic,
@@ -597,7 +596,7 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 		},
 		{
 			desc: "openshift-logging mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -606,7 +605,7 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
 							EnableV2: false,
@@ -650,7 +649,7 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 		},
 		{
 			desc: "openshift-network mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,
@@ -659,7 +658,7 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
 							EnableV2: false,
@@ -686,8 +685,8 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := manifests.ConfigOptions(tc.opts)
-			err := manifests.ConfigureOptionsForMode(&cfg, tc.opts)
+			cfg := ConfigOptions(tc.opts)
+			err := ConfigureOptionsForMode(&cfg, tc.opts)
 			require.Nil(t, err)
 			require.EqualValues(t, tc.wantOptions, cfg.Overrides)
 		})
@@ -697,12 +696,12 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 func TestConfigOptions_RulerOverrides(t *testing.T) {
 	tt := []struct {
 		desc        string
-		opts        manifests.Options
+		opts        Options
 		wantOptions map[string]config.LokiOverrides
 	}{
 		{
 			desc: "static mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Static,
@@ -713,7 +712,7 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 		},
 		{
 			desc: "dynamic mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Dynamic,
@@ -724,7 +723,7 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 		},
 		{
 			desc: "openshift-logging mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -733,7 +732,7 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
 							EnableV2: false,
@@ -855,7 +854,7 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 		},
 		{
 			desc: "openshift-network mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -864,7 +863,7 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
 							EnableV2: false,
@@ -891,8 +890,8 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := manifests.ConfigOptions(tc.opts)
-			err := manifests.ConfigureOptionsForMode(&cfg, tc.opts)
+			cfg := ConfigOptions(tc.opts)
+			err := ConfigureOptionsForMode(&cfg, tc.opts)
 			require.Nil(t, err)
 			require.EqualValues(t, tc.wantOptions, cfg.Overrides)
 		})
@@ -902,13 +901,13 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 	tt := []struct {
 		desc                 string
-		opts                 manifests.Options
+		opts                 Options
 		wantOptions          *config.AlertManagerConfig
 		wantOverridesOptions map[string]config.LokiOverrides
 	}{
 		{
 			desc: "static mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Static,
@@ -920,7 +919,7 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 		},
 		{
 			desc: "dynamic mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Dynamic,
@@ -932,7 +931,7 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 		},
 		{
 			desc: "openshift-logging mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -941,7 +940,7 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
 							EnableV2: false,
@@ -991,7 +990,7 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 		},
 		{
 			desc: "openshift-network mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,
@@ -1000,7 +999,7 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
 							EnableV2: false,
@@ -1033,8 +1032,8 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := manifests.ConfigOptions(tc.opts)
-			err := manifests.ConfigureOptionsForMode(&cfg, tc.opts)
+			cfg := ConfigOptions(tc.opts)
+			err := ConfigureOptionsForMode(&cfg, tc.opts)
 			require.Nil(t, err)
 			require.EqualValues(t, tc.wantOverridesOptions, cfg.Overrides)
 			require.EqualValues(t, tc.wantOptions, cfg.Ruler.AlertManager)

--- a/operator/internal/manifests/distributor_test.go
+++ b/operator/internal/manifests/distributor_test.go
@@ -1,15 +1,14 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewDistributorDeployment_SelectorMatchesLabels(t *testing.T) {
-	dpl := manifests.NewDistributorDeployment(manifests.Options{
+	dpl := NewDistributorDeployment(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -29,7 +28,7 @@ func TestNewDistributorDeployment_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestNewDistributorDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewDistributorDeployment(manifests.Options{
+	ss := NewDistributorDeployment(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -49,7 +48,7 @@ func TestNewDistributorDeployment_HasTemplateConfigHashAnnotation(t *testing.T) 
 }
 
 func TestNewDistributorDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewDistributorDeployment(manifests.Options{
+	ss := NewDistributorDeployment(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",

--- a/operator/internal/manifests/indexgateway_test.go
+++ b/operator/internal/manifests/indexgateway_test.go
@@ -1,15 +1,14 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewIndexGatewayStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	ss := NewIndexGatewayStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -30,7 +29,7 @@ func TestNewIndexGatewayStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T
 }
 
 func TestNewIndexGatewayStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	ss := NewIndexGatewayStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -56,7 +55,7 @@ func TestNewIndexGatewayStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	ss := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	ss := NewIndexGatewayStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/ingester_test.go
+++ b/operator/internal/manifests/ingester_test.go
@@ -1,15 +1,14 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewIngesterStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewIngesterStatefulSet(manifests.Options{
+	ss := NewIngesterStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -30,7 +29,7 @@ func TestNewIngesterStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewIngesterStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewIngesterStatefulSet(manifests.Options{
+	ss := NewIngesterStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -56,7 +55,7 @@ func TestNewIngesterStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	sts := manifests.NewIngesterStatefulSet(manifests.Options{
+	sts := NewIngesterStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/mutate_test.go
+++ b/operator/internal/manifests/mutate_test.go
@@ -1,9 +1,7 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
-
-	"github.com/grafana/loki/operator/internal/manifests"
 
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -40,7 +38,7 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 	}
 
 	got := &corev1.ConfigMap{}
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -53,7 +51,7 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 func TestGetMutateFunc_ReturnErrOnNotSupportedType(t *testing.T) {
 	got := &corev1.Endpoints{}
 	want := &corev1.Endpoints{}
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 
 	require.Error(t, f())
 }
@@ -69,7 +67,7 @@ func TestGetMutateFunc_MutateConfigMap(t *testing.T) {
 		BinaryData: map[string][]byte{"btest": []byte("btestss")},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -116,7 +114,7 @@ func TestGetMutateFunc_MutateServiceSpec(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -231,7 +229,7 @@ func TestGetMutateFunc_MutateServiceAccountObjectMeta(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tt.got, tt.want, nil)
+			f := MutateFuncFor(tt.got, tt.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -293,7 +291,7 @@ func TestGetMutateFunc_MutateClusterRole(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -358,7 +356,7 @@ func TestGetMutateFunc_MutateClusterRoleBinding(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -413,7 +411,7 @@ func TestGetMutateFunc_MutateRole(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -478,7 +476,7 @@ func TestGetMutateFunc_MutateRoleBinding(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -597,7 +595,7 @@ func TestGeMutateFunc_MutateDeploymentSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tst.got, tst.want, nil)
+			f := MutateFuncFor(tst.got, tst.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -754,7 +752,7 @@ func TestGeMutateFunc_MutateStatefulSetSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tst.got, tst.want, nil)
+			f := MutateFuncFor(tst.got, tst.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -790,12 +788,12 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -817,24 +815,24 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 						{
 							Port:            "loki-test",
 							Path:            "/some-new-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -861,12 +859,12 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -893,24 +891,24 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 						{
 							Port:            "loki-test",
 							Path:            "/some-new-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -931,7 +929,7 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tst.got, tst.want, nil)
+			f := MutateFuncFor(tst.got, tst.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -1003,7 +1001,7 @@ func TestGetMutateFunc_MutateIngress(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -1055,7 +1053,7 @@ func TestGetMutateFunc_MutateRoute(t *testing.T) {
 			},
 		},
 	}
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 
 	err := f()
 	require.NoError(t, err)

--- a/operator/internal/manifests/querier_test.go
+++ b/operator/internal/manifests/querier_test.go
@@ -1,15 +1,14 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewQuerierDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewQuerierDeployment(manifests.Options{
+	ss := NewQuerierDeployment(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -30,7 +29,7 @@ func TestNewQuerierDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewQuerierDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewQuerierDeployment(manifests.Options{
+	ss := NewQuerierDeployment(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -56,7 +55,7 @@ func TestNewQuerierDeployment_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during Deployment creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	ss := manifests.NewQuerierDeployment(manifests.Options{
+	ss := NewQuerierDeployment(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/ruler_test.go
+++ b/operator/internal/manifests/ruler_test.go
@@ -1,18 +1,17 @@
-package manifests_test
+package manifests
 
 import (
 	"math/rand"
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/grafana/loki/operator/internal/manifests/openshift"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNewRulerStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewRulerStatefulSet(manifests.Options{
+	ss := NewRulerStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -33,7 +32,7 @@ func TestNewRulerStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewRulerStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewRulerStatefulSet(manifests.Options{
+	ss := NewRulerStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -53,7 +52,7 @@ func TestNewRulerStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *test
 }
 
 func TestBuildRuler_HasExtraObjectsForTenantMode(t *testing.T) {
-	objs, err := manifests.BuildRuler(manifests.Options{
+	objs, err := BuildRuler(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		OpenShiftOptions: openshift.Options{
@@ -88,7 +87,7 @@ func TestNewRulerStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	sts := manifests.NewRulerStatefulSet(manifests.Options{
+	sts := NewRulerStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -109,7 +108,7 @@ func TestNewRulerStatefulSet_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestNewRulerStatefulSet_MountsRulesInPerTenantIDSubDirectories(t *testing.T) {
-	opts := manifests.Options{
+	opts := Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -120,15 +119,15 @@ func TestNewRulerStatefulSet_MountsRulesInPerTenantIDSubDirectories(t *testing.T
 				},
 			},
 		},
-		Tenants: manifests.Tenants{
-			Configs: map[string]manifests.TenantConfig{
+		Tenants: Tenants{
+			Configs: map[string]TenantConfig{
 				"tenant-a": {RuleFiles: []string{"test-rules-0___tenant-a___rule-a-alerts.yaml", "test-rules-0___tenant-a___rule-b-recs.yaml"}},
 				"tenant-b": {RuleFiles: []string{"test-rules-0___tenant-b___rule-a-alerts.yaml", "test-rules-0___tenant-b___rule-b-recs.yaml"}},
 			},
 		},
 		RulesConfigMapNames: []string{"config"},
 	}
-	sts := manifests.NewRulerStatefulSet(opts)
+	sts := NewRulerStatefulSet(opts)
 
 	vs := sts.Spec.Template.Spec.Volumes
 
@@ -143,7 +142,7 @@ func TestNewRulerStatefulSet_MountsRulesInPerTenantIDSubDirectories(t *testing.T
 func TestNewRulerStatefulSet_ShardedRulesConfigMap(t *testing.T) {
 	// Create a large config map which will be split into 2 shards
 	opts := testOptions_withSharding()
-	rulesCMShards, err := manifests.RulesConfigMapShards(opts)
+	rulesCMShards, err := RulesConfigMapShards(opts)
 	require.NoError(t, err)
 	require.NotNil(t, rulesCMShards)
 	require.Len(t, rulesCMShards, 2)
@@ -153,7 +152,7 @@ func TestNewRulerStatefulSet_ShardedRulesConfigMap(t *testing.T) {
 	}
 
 	// Create the Ruler StatefulSet and mount the ConfigMap shards into the Ruler pod
-	sts := manifests.NewRulerStatefulSet(*opts)
+	sts := NewRulerStatefulSet(*opts)
 
 	vs := sts.Spec.Template.Spec.Volumes
 
@@ -161,7 +160,7 @@ func TestNewRulerStatefulSet_ShardedRulesConfigMap(t *testing.T) {
 	var volumeProjections []corev1.VolumeProjection
 	for _, v := range vs {
 		volumeNames = append(volumeNames, v.Name)
-		if v.Name == manifests.RulesStorageVolumeName() {
+		if v.Name == RulesStorageVolumeName() {
 			volumeProjections = append(volumeProjections, v.Projected.Sources...)
 		}
 	}

--- a/operator/internal/manifests/rules_config_test.go
+++ b/operator/internal/manifests/rules_config_test.go
@@ -1,18 +1,17 @@
-package manifests_test
+package manifests
 
 import (
 	"fmt"
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestRulesConfigMap_ReturnsDataEntriesPerRule(t *testing.T) {
-	cm_shards, err := manifests.RulesConfigMapShards(testOptions())
+	cm_shards, err := RulesConfigMapShards(testOptions())
 	require.NoError(t, err)
 	require.NotNil(t, cm_shards)
 
@@ -27,7 +26,7 @@ func TestRulesConfigMap_ReturnsDataEntriesPerRule(t *testing.T) {
 
 func TestRulesConfigMap_ReturnsTenantMapPerRule(t *testing.T) {
 	opts := testOptions()
-	cm_shards, err := manifests.RulesConfigMapShards(opts)
+	cm_shards, err := RulesConfigMapShards(opts)
 	require.NoError(t, err)
 	require.NotNil(t, cm_shards)
 
@@ -40,16 +39,16 @@ func TestRulesConfigMap_ReturnsTenantMapPerRule(t *testing.T) {
 }
 
 func TestRulesConfigMapSharding(t *testing.T) {
-	cm_shards, err := manifests.RulesConfigMapShards(testOptions_withSharding())
+	cm_shards, err := RulesConfigMapShards(testOptions_withSharding())
 	require.NoError(t, err)
 	require.NotNil(t, cm_shards)
 	require.Len(t, cm_shards, 2)
 }
 
-func testOptions() *manifests.Options {
-	return &manifests.Options{
-		Tenants: manifests.Tenants{
-			Configs: map[string]manifests.TenantConfig{
+func testOptions() *Options {
+	return &Options{
+		Tenants: Tenants{
+			Configs: map[string]TenantConfig{
 				"tenant-a": {},
 				"tenant-b": {},
 			},
@@ -133,7 +132,7 @@ func testOptions() *manifests.Options {
 	}
 }
 
-func testOptions_withSharding() *manifests.Options {
+func testOptions_withSharding() *Options {
 	// Generate a list of dummy rules to create a large amount of data
 	// that should result in sharding the rules ConfigMap
 	// In this case, each Alerting rule amounts to 598 bytes of ConfigMap data
@@ -169,7 +168,7 @@ func testOptions_withSharding() *manifests.Options {
 		})
 	}
 
-	return &manifests.Options{
+	return &Options{
 		Name:      "sharding-test",
 		Namespace: "namespace",
 		Stack: lokiv1.LokiStackSpec{
@@ -180,8 +179,8 @@ func testOptions_withSharding() *manifests.Options {
 				},
 			},
 		},
-		Tenants: manifests.Tenants{
-			Configs: map[string]manifests.TenantConfig{
+		Tenants: Tenants{
+			Configs: map[string]TenantConfig{
 				"tenant-a": {},
 				"tenant-b": {},
 			},


### PR DESCRIPTION
What this PR does / why we need it**:
https://github.com/grafana/loki/pull/9433
Moves all the unit tests under operator/manifests to the manifests package making all test files now uniform.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
