### PR TITLE
[release-5.6] Backport PR grafana/loki#9433 

### DIFF
--- a/operator/internal/manifests/compactor_test.go
+++ b/operator/internal/manifests/compactor_test.go
@@ -1,10 +1,9 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,7 +14,7 @@ func TestNewCompactorStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	sts := manifests.NewCompactorStatefulSet(manifests.Options{
+	sts := NewCompactorStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -36,7 +35,7 @@ func TestNewCompactorStatefulSet_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestNewCompactorStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewCompactorStatefulSet(manifests.Options{
+	ss := NewCompactorStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -56,7 +55,7 @@ func TestNewCompactorStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewCompactorStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewCompactorStatefulSet(manifests.Options{
+	ss := NewCompactorStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -1,4 +1,4 @@
-package manifests_test
+package manifests
 
 import (
 	"encoding/json"
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/grafana/loki/operator/apis/loki/v1beta1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	"github.com/grafana/loki/operator/internal/manifests/openshift"
 	"github.com/stretchr/testify/assert"
@@ -20,17 +19,17 @@ import (
 func TestConfigMap_ReturnsSHA1OfBinaryContents(t *testing.T) {
 	opts := randomConfigOptions()
 
-	_, sha1C, err := manifests.LokiConfigMap(opts)
+	_, sha1C, err := LokiConfigMap(opts)
 	require.NoError(t, err)
 	require.NotEmpty(t, sha1C)
 }
 
 func TestConfigOptions_UserOptionsTakePrecedence(t *testing.T) {
 	// regardless of what is provided by the default sizing parameters we should always prefer
-	// the user-defined values. This creates an all-inclusive manifests.Options and then checks
+	// the user-defined values. This creates an all-inclusive Options and then checks
 	// that every value is present in the result
 	opts := randomConfigOptions()
-	res := manifests.ConfigOptions(opts)
+	res := ConfigOptions(opts)
 
 	expected, err := json.Marshal(opts.Stack)
 	require.NoError(t, err)
@@ -41,8 +40,8 @@ func TestConfigOptions_UserOptionsTakePrecedence(t *testing.T) {
 	assert.JSONEq(t, string(expected), string(actual))
 }
 
-func randomConfigOptions() manifests.Options {
-	return manifests.Options{
+func randomConfigOptions() Options {
+	return Options{
 		Name:      uuid.New().String(),
 		Namespace: uuid.New().String(),
 		Image:     uuid.New().String(),
@@ -250,12 +249,12 @@ func TestConfigOptions_GossipRingConfig(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			inOpt := manifests.Options{
+			inOpt := Options{
 				Name:      "my-stack",
 				Namespace: "my-ns",
 				Stack:     tc.spec,
 			}
-			options := manifests.ConfigOptions(inOpt)
+			options := ConfigOptions(inOpt)
 			require.Equal(t, tc.wantOptions, options.GossipRing)
 		})
 	}
@@ -358,10 +357,10 @@ func TestConfigOptions_RetentionConfig(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			inOpt := manifests.Options{
+			inOpt := Options{
 				Stack: tc.spec,
 			}
-			options := manifests.ConfigOptions(inOpt)
+			options := ConfigOptions(inOpt)
 			require.Equal(t, tc.wantOptions, options.Retention)
 		})
 	}
@@ -370,12 +369,12 @@ func TestConfigOptions_RetentionConfig(t *testing.T) {
 func TestConfigOptions_RulerAlertManager(t *testing.T) {
 	tt := []struct {
 		desc        string
-		opts        manifests.Options
+		opts        Options
 		wantOptions *config.AlertManagerConfig
 	}{
 		{
 			desc: "static mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Static,
@@ -386,7 +385,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 		},
 		{
 			desc: "dynamic mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Dynamic,
@@ -397,7 +396,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 		},
 		{
 			desc: "openshift-logging mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -418,7 +417,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 		},
 		{
 			desc: "openshift-network mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,
@@ -444,8 +443,8 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := manifests.ConfigOptions(tc.opts)
-			err := manifests.ConfigureOptionsForMode(&cfg, tc.opts)
+			cfg := ConfigOptions(tc.opts)
+			err := ConfigureOptionsForMode(&cfg, tc.opts)
 
 			require.Nil(t, err)
 			require.Equal(t, tc.wantOptions, cfg.Ruler.AlertManager)
@@ -456,12 +455,12 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 	tt := []struct {
 		desc        string
-		opts        manifests.Options
+		opts        Options
 		wantOptions *config.AlertManagerConfig
 	}{
 		{
 			desc: "static mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Static,
@@ -472,7 +471,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 		},
 		{
 			desc: "dynamic mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.Dynamic,
@@ -483,7 +482,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 		},
 		{
 			desc: "openshift-logging mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -492,7 +491,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &v1beta1.RulerConfigSpec{
 						AlertManagerSpec: &v1beta1.AlertManagerSpec{
 							EnableV2: false,
@@ -519,7 +518,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 		},
 		{
 			desc: "openshift-network mode",
-			opts: manifests.Options{
+			opts: Options{
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,
@@ -528,7 +527,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 						Enabled: true,
 					},
 				},
-				Ruler: manifests.Ruler{
+				Ruler: Ruler{
 					Spec: &v1beta1.RulerConfigSpec{
 						AlertManagerSpec: &v1beta1.AlertManagerSpec{
 							EnableV2: false,
@@ -560,8 +559,8 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			cfg := manifests.ConfigOptions(tc.opts)
-			err := manifests.ConfigureOptionsForMode(&cfg, tc.opts)
+			cfg := ConfigOptions(tc.opts)
+			err := ConfigureOptionsForMode(&cfg, tc.opts)
 			require.Nil(t, err)
 			require.Equal(t, tc.wantOptions, cfg.Ruler.AlertManager)
 		})

--- a/operator/internal/manifests/distributor_test.go
+++ b/operator/internal/manifests/distributor_test.go
@@ -1,15 +1,14 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewDistributorDeployment_SelectorMatchesLabels(t *testing.T) {
-	dpl := manifests.NewDistributorDeployment(manifests.Options{
+	dpl := NewDistributorDeployment(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -29,7 +28,7 @@ func TestNewDistributorDeployment_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestNewDistributorDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewDistributorDeployment(manifests.Options{
+	ss := NewDistributorDeployment(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -49,7 +48,7 @@ func TestNewDistributorDeployment_HasTemplateConfigHashAnnotation(t *testing.T) 
 }
 
 func TestNewDistributorDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewDistributorDeployment(manifests.Options{
+	ss := NewDistributorDeployment(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",

--- a/operator/internal/manifests/indexgateway_test.go
+++ b/operator/internal/manifests/indexgateway_test.go
@@ -1,15 +1,14 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewIndexGatewayStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	ss := NewIndexGatewayStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -30,7 +29,7 @@ func TestNewIndexGatewayStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T
 }
 
 func TestNewIndexGatewayStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	ss := NewIndexGatewayStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -56,7 +55,7 @@ func TestNewIndexGatewayStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	ss := manifests.NewIndexGatewayStatefulSet(manifests.Options{
+	ss := NewIndexGatewayStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/ingester_test.go
+++ b/operator/internal/manifests/ingester_test.go
@@ -1,15 +1,14 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewIngesterStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewIngesterStatefulSet(manifests.Options{
+	ss := NewIngesterStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -30,7 +29,7 @@ func TestNewIngesterStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewIngesterStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewIngesterStatefulSet(manifests.Options{
+	ss := NewIngesterStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -56,7 +55,7 @@ func TestNewIngesterStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	sts := manifests.NewIngesterStatefulSet(manifests.Options{
+	sts := NewIngesterStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/mutate_test.go
+++ b/operator/internal/manifests/mutate_test.go
@@ -1,9 +1,7 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
-
-	"github.com/grafana/loki/operator/internal/manifests"
 
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -40,7 +38,7 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 	}
 
 	got := &corev1.ConfigMap{}
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -53,7 +51,7 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 func TestGetMutateFunc_ReturnErrOnNotSupportedType(t *testing.T) {
 	got := &corev1.Endpoints{}
 	want := &corev1.Endpoints{}
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 
 	require.Error(t, f())
 }
@@ -69,7 +67,7 @@ func TestGetMutateFunc_MutateConfigMap(t *testing.T) {
 		BinaryData: map[string][]byte{"btest": []byte("btestss")},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -116,7 +114,7 @@ func TestGetMutateFunc_MutateServiceSpec(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -231,7 +229,7 @@ func TestGetMutateFunc_MutateServiceAccountObjectMeta(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tt.got, tt.want, nil)
+			f := MutateFuncFor(tt.got, tt.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -293,7 +291,7 @@ func TestGetMutateFunc_MutateClusterRole(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -358,7 +356,7 @@ func TestGetMutateFunc_MutateClusterRoleBinding(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -413,7 +411,7 @@ func TestGetMutateFunc_MutateRole(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -478,7 +476,7 @@ func TestGetMutateFunc_MutateRoleBinding(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -597,7 +595,7 @@ func TestGeMutateFunc_MutateDeploymentSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tst.got, tst.want, nil)
+			f := MutateFuncFor(tst.got, tst.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -754,7 +752,7 @@ func TestGeMutateFunc_MutateStatefulSetSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tst.got, tst.want, nil)
+			f := MutateFuncFor(tst.got, tst.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -790,12 +788,12 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -817,24 +815,24 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 						{
 							Port:            "loki-test",
 							Path:            "/some-new-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -861,12 +859,12 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -893,24 +891,24 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 							Port:            "loki-test",
 							Path:            "/some-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 						{
 							Port:            "loki-test",
 							Path:            "/some-new-path",
 							Scheme:          "https",
-							BearerTokenFile: manifests.BearerTokenFile,
+							BearerTokenFile: BearerTokenFile,
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
 									ServerName: "loki-test.some-ns.svc.cluster.local",
 								},
-								CAFile: manifests.PrometheusCAFile,
+								CAFile: PrometheusCAFile,
 							},
 						},
 					},
@@ -931,7 +929,7 @@ func TestGetMutateFunc_MutateServiceMonitorSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := manifests.MutateFuncFor(tst.got, tst.want, nil)
+			f := MutateFuncFor(tst.got, tst.want, nil)
 			err := f()
 			require.NoError(t, err)
 
@@ -1003,7 +1001,7 @@ func TestGetMutateFunc_MutateIngress(t *testing.T) {
 		},
 	}
 
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 	err := f()
 	require.NoError(t, err)
 
@@ -1055,7 +1053,7 @@ func TestGetMutateFunc_MutateRoute(t *testing.T) {
 			},
 		},
 	}
-	f := manifests.MutateFuncFor(got, want, nil)
+	f := MutateFuncFor(got, want, nil)
 
 	err := f()
 	require.NoError(t, err)

--- a/operator/internal/manifests/querier_test.go
+++ b/operator/internal/manifests/querier_test.go
@@ -1,15 +1,14 @@
-package manifests_test
+package manifests
 
 import (
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewQuerierDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewQuerierDeployment(manifests.Options{
+	ss := NewQuerierDeployment(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -30,7 +29,7 @@ func TestNewQuerierDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewQuerierDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewQuerierDeployment(manifests.Options{
+	ss := NewQuerierDeployment(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -56,7 +55,7 @@ func TestNewQuerierDeployment_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during Deployment creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	ss := manifests.NewQuerierDeployment(manifests.Options{
+	ss := NewQuerierDeployment(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{

--- a/operator/internal/manifests/ruler_test.go
+++ b/operator/internal/manifests/ruler_test.go
@@ -1,18 +1,17 @@
-package manifests_test
+package manifests
 
 import (
 	"math/rand"
 	"testing"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/grafana/loki/operator/internal/manifests/openshift"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func TestNewRulerStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
-	ss := manifests.NewRulerStatefulSet(manifests.Options{
+	ss := NewRulerStatefulSet(Options{
 		Name:       "abcd",
 		Namespace:  "efgh",
 		ConfigSHA1: "deadbeef",
@@ -33,7 +32,7 @@ func TestNewRulerStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 }
 
 func TestNewRulerStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *testing.T) {
-	ss := manifests.NewRulerStatefulSet(manifests.Options{
+	ss := NewRulerStatefulSet(Options{
 		Name:                   "abcd",
 		Namespace:              "efgh",
 		CertRotationRequiredAt: "deadbeef",
@@ -53,7 +52,7 @@ func TestNewRulerStatefulSet_HasTemplateCertRotationRequiredAtAnnotation(t *test
 }
 
 func TestBuildRuler_HasExtraObjectsForTenantMode(t *testing.T) {
-	objs, err := manifests.BuildRuler(manifests.Options{
+	objs, err := BuildRuler(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		OpenShiftOptions: openshift.Options{
@@ -88,7 +87,7 @@ func TestNewRulerStatefulSet_SelectorMatchesLabels(t *testing.T) {
 	// failing to specify a matching Pod Selector will result in a validation error
 	// during StatefulSet creation.
 	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
-	sts := manifests.NewRulerStatefulSet(manifests.Options{
+	sts := NewRulerStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -109,7 +108,7 @@ func TestNewRulerStatefulSet_SelectorMatchesLabels(t *testing.T) {
 }
 
 func TestNewRulerStatefulSet_MountsRulesInPerTenantIDSubDirectories(t *testing.T) {
-	sts := manifests.NewRulerStatefulSet(manifests.Options{
+	sts := NewRulerStatefulSet(Options{
 		Name:      "abcd",
 		Namespace: "efgh",
 		Stack: lokiv1.LokiStackSpec{
@@ -120,8 +119,8 @@ func TestNewRulerStatefulSet_MountsRulesInPerTenantIDSubDirectories(t *testing.T
 				},
 			},
 		},
-		Tenants: manifests.Tenants{
-			Configs: map[string]manifests.TenantConfig{
+		Tenants: Tenants{
+			Configs: map[string]TenantConfig{
 				"tenant-a": {RuleFiles: []string{"rule-a-alerts.yaml", "rule-b-recs.yaml"}},
 				"tenant-b": {RuleFiles: []string{"rule-a-alerts.yaml", "rule-b-recs.yaml"}},
 			},

--- a/operator/internal/manifests/rules_config_test.go
+++ b/operator/internal/manifests/rules_config_test.go
@@ -1,18 +1,17 @@
-package manifests_test
+package manifests
 
 import (
 	"fmt"
 	"testing"
 
 	lokiv1beta1 "github.com/grafana/loki/operator/apis/loki/v1beta1"
-	"github.com/grafana/loki/operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestRulesConfigMap_ReturnsDataEntriesPerRule(t *testing.T) {
-	cm, err := manifests.RulesConfigMap(testOptions())
+	cm, err := RulesConfigMap(testOptions())
 	require.NoError(t, err)
 	require.NotNil(t, cm)
 	require.Len(t, cm.Data, 4)
@@ -24,7 +23,7 @@ func TestRulesConfigMap_ReturnsDataEntriesPerRule(t *testing.T) {
 
 func TestRulesConfigMap_ReturnsTenantMapPerRule(t *testing.T) {
 	opts := testOptions()
-	cm, err := manifests.RulesConfigMap(opts)
+	cm, err := RulesConfigMap(opts)
 	require.NoError(t, err)
 	require.NotNil(t, cm)
 	require.Len(t, cm.Data, 4)
@@ -35,10 +34,10 @@ func TestRulesConfigMap_ReturnsTenantMapPerRule(t *testing.T) {
 	require.Contains(t, opts.Tenants.Configs["tenant-b"].RuleFiles, "prod-recording-rules-recs2.yaml")
 }
 
-func testOptions() *manifests.Options {
-	return &manifests.Options{
-		Tenants: manifests.Tenants{
-			Configs: map[string]manifests.TenantConfig{
+func testOptions() *Options {
+	return &Options{
+		Tenants: Tenants{
+			Configs: map[string]TenantConfig{
 				"tenant-a": {},
 				"tenant-b": {},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/loki/pull/9433
Moves all the unit tests under operator/manifests to the manifests package making all test files now uniform.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
