### PR TITLE
build: update loki and promtail Dockerfile base image to RHEL 9

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/grafana/loki
 COPY . .
 RUN touch loki-build-image/.uptodate && mkdir /build
 RUN make clean && make BUILD_IN_CONTAINER=false loki
 
-FROM  registry.ci.openshift.org/ocp/4.12:base
+FROM  registry.ci.openshift.org/ocp/4.14:base
 LABEL io.k8s.display-name="OpenShift Loki" \
       io.k8s.description="Horizontally-scalable, highly-available, multi-tenant log aggregation system inspired by Prometheus." \
       io.openshift.tags="grafana,prometheus,monitoring" \

--- a/Dockerfile.promtail.ocp
+++ b/Dockerfile.promtail.ocp
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/grafana/loki
 COPY . .
 RUN touch loki-build-image/.uptodate && mkdir /build
 RUN make clean && make BUILD_IN_CONTAINER=false promtail
 
-FROM  registry.ci.openshift.org/ocp/4.12:base
+FROM  registry.ci.openshift.org/ocp/4.14:base
 LABEL io.k8s.display-name="OpenShift Loki Promtail" \
       io.k8s.description="An agent responsible for gathering logs and sending them to Loki." \
       io.openshift.tags="grafana,prometheus,monitoring" \


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates both loki and promtail Drockerfiles to RHEL 9 part of https://issues.redhat.com/browse/LOG-4054

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
