### PR TITLE
[release-5.7] Backport PR grafana/loki#9346

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [9346](https://github.com/grafana/loki/pull/9346) **periklis**: Enable Route by default on OpenShift clusters
 - [9036](https://github.com/grafana/loki/pull/9036) **periklis**: Update Loki operand to v2.8.0
 - [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret
 - [8958](https://github.com/grafana/loki/pull/8958) **periklis**: Align common instance addr with memberlist advertise addr

--- a/operator/apis/config/v1/projectconfig_types.go
+++ b/operator/apis/config/v1/projectconfig_types.go
@@ -28,16 +28,14 @@ type BuiltInCertManagement struct {
 
 // OpenShiftFeatureGates is the supported set of all operator features gates on OpenShift.
 type OpenShiftFeatureGates struct {
+	// Enabled defines the flag to enable that these feature gates are used against OpenShift Container Platform releases.
+	Enabled bool `json:"enabled,omitempty"`
+
 	// ServingCertsService enables OpenShift service-ca annotations on the lokistack-gateway service only
 	// to use the in-platform CA and generate a TLS cert/key pair per service for
 	// in-cluster data-in-transit encryption.
 	// More details: https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/service-ca-certificates.html
 	ServingCertsService bool `json:"servingCertsService,omitempty"`
-
-	// GatewayRoute enables creating an OpenShift Route for the LokiStack
-	// gateway to expose the service to public internet access.
-	// More details: https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html
-	GatewayRoute bool `json:"gatewayRoute,omitempty"`
 
 	// ExtendedRuleValidation enables extended validation of AlertingRule and RecordingRule
 	// to enforce tenancy in an OpenShift context.

--- a/operator/bundle/community-openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -51,8 +51,8 @@ data:
       # OpenShift feature gates
       #
       openshift:
+        enabled: true
         servingCertsService: true
-        gatewayRoute: true
         ruleExtendedValidation: true
         clusterTLSPolicy: true
         clusterProxy: true

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-05-04T16:51:30Z"
+    createdAt: "2023-05-23T07:47:18Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1206,7 +1206,6 @@ spec:
 
     In addition it enables the following OpenShift-only related feature gates:
     * `servingCertsService`: Enables OpenShift ServiceCA annotations on the lokistack-gateway service only.
-    * `gatewayRoute`: Enables creating an OpenShift Route for the LokiStack.
     * `ruleExtendedValidation`: Enables extended validation of AlertingRule and RecordingRule to enforce tenancy in an OpenShift context.
     * `clusterTLSPolicy`: Enables usage of TLS policies set in the API Server.
     * `clusterProxy`: Enables usage of the proxy variables set in the proxy resource.

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-05-04T16:51:25Z"
+    createdAt: "2023-05-23T07:47:15Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -54,8 +54,8 @@ data:
       # OpenShift feature gates
       #
       openshift:
+        enabled: true
         servingCertsService: true
-        gatewayRoute: true
         ruleExtendedValidation: true
         clusterTLSPolicy: true
         clusterProxy: true

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2023-05-04T16:51:35Z"
+    createdAt: "2023-05-23T07:47:20Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -2023,7 +2023,6 @@ spec:
 
     In addition it enables the following OpenShift-only related feature gates:
     * `servingCertsService`: Enables OpenShift ServiceCA annotations on the lokistack-gateway service only.
-    * `gatewayRoute`: Enables creating an OpenShift Route for the LokiStack.
     * `ruleExtendedValidation`: Enables extended validation of AlertingRule and RecordingRule to enforce tenancy in an OpenShift context.
     * `clusterTLSPolicy`: Enables usage of TLS policies set in the API Server.
     * `clusterProxy`: Enables usage of the proxy variables set in the proxy resource.

--- a/operator/config/overlays/community-openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/community-openshift/controller_manager_config.yaml
@@ -48,8 +48,8 @@ featureGates:
   # OpenShift feature gates
   #
   openshift:
+    enabled: true
     servingCertsService: true
-    gatewayRoute: true
     ruleExtendedValidation: true
     clusterTLSPolicy: true
     clusterProxy: true

--- a/operator/config/overlays/openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/openshift/controller_manager_config.yaml
@@ -51,8 +51,8 @@ featureGates:
   # OpenShift feature gates
   #
   openshift:
+    enabled: true
     servingCertsService: true
-    gatewayRoute: true
     ruleExtendedValidation: true
     clusterTLSPolicy: true
     clusterProxy: true

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -217,7 +217,7 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 		bld = bld.Owns(&monitoringv1.PrometheusRule{}, updateOrDeleteOnlyPred)
 	}
 
-	if r.FeatureGates.OpenShift.GatewayRoute {
+	if r.FeatureGates.OpenShift.Enabled {
 		bld = bld.Owns(&routev1.Route{}, updateOrDeleteOnlyPred)
 	} else {
 		bld = bld.Owns(&networkingv1.Ingress{}, updateOrDeleteOnlyPred)

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -152,7 +152,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			ownCallsCount: 11,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
-					GatewayRoute: false,
+					Enabled: false,
 				},
 			},
 			pred: updateOrDeleteOnlyPred,
@@ -163,7 +163,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			ownCallsCount: 11,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
-					GatewayRoute: true,
+					Enabled: true,
 				},
 			},
 			pred: updateOrDeleteOnlyPred,

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -1604,10 +1604,12 @@ are degraded or the cluster cannot connect to object storage.</p>
 </thead>
 <tbody><tr><td><p>&#34;1x.extra-small&#34;</p></td>
 <td><p>SizeOneXExtraSmall defines the size of a single Loki deployment
-with extra small resources/limits requirements and without HA support.
-This size is ultimately dedicated for development and demo purposes.
-DO NOT USE THIS IN PRODUCTION!</p>
-<p>FIXME: Add clear description of ingestion/query performance expectations.</p>
+with minimal resource requirements and without HA support.</p>
+<p>This is ONLY for development, testing, or demos on limited single-node clusters.
+There are NO performance guarantees.
+LokiStack will use whatever resources are available,
+and WILL NOT FUNCTION CORRECTLY if there is not enough memory or CPU.</p>
+<p>DO NOT USE THIS IN PRODUCTION!</p>
 </td>
 </tr><tr><td><p>&#34;1x.medium&#34;</p></td>
 <td><p>SizeOneXMedium defines the size of a single Loki deployment

--- a/operator/docs/operator/feature-gates.md
+++ b/operator/docs/operator/feature-gates.md
@@ -342,6 +342,17 @@ when using HTTPEncryption or GRPCEncryption.</p>
 <tbody>
 <tr>
 <td>
+<code>enabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Enabled defines the flag to enable that these feature gates are used against OpenShift Container Platform releases.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>servingCertsService</code><br/>
 <em>
 bool
@@ -352,19 +363,6 @@ bool
 to use the in-platform CA and generate a TLS cert/key pair per service for
 in-cluster data-in-transit encryption.
 More details: <a href="https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/service-ca-certificates.html">https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/service-ca-certificates.html</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>gatewayRoute</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>GatewayRoute enables creating an OpenShift Route for the LokiStack
-gateway to expose the service to public internet access.
-More details: <a href="https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html">https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html</a></p>
 </td>
 </tr>
 <tr>

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -43,6 +43,50 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 			},
 		},
 		{
+			desc: "static mode on openshift",
+			opts: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Static,
+					},
+				},
+			},
+			want: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Static,
+					},
+				},
+				OpenShiftOptions: openshift.Options{
+					BuildOpts: openshift.BuildOptions{
+						LokiStackName:        "lokistack-ocp",
+						LokiStackNamespace:   "stack-ns",
+						GatewayName:          "lokistack-ocp-gateway",
+						GatewaySvcName:       "lokistack-ocp-gateway-http",
+						GatewaySvcTargetPort: "public",
+						RulerName:            "lokistack-ocp-ruler",
+						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
+					},
+				},
+			},
+		},
+		{
 			desc: "dynamic mode",
 			opts: &Options{
 				Stack: lokiv1.LokiStackSpec{
@@ -60,11 +104,60 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 			},
 		},
 		{
+			desc: "dynamic mode on openshift",
+			opts: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Dynamic,
+					},
+				},
+			},
+			want: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Dynamic,
+					},
+				},
+				OpenShiftOptions: openshift.Options{
+					BuildOpts: openshift.BuildOptions{
+						LokiStackName:        "lokistack-ocp",
+						LokiStackNamespace:   "stack-ns",
+						GatewayName:          "lokistack-ocp-gateway",
+						GatewaySvcName:       "lokistack-ocp-gateway-http",
+						GatewaySvcTargetPort: "public",
+						RulerName:            "lokistack-ocp-ruler",
+						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
+					},
+				},
+			},
+		},
+		{
 			desc: "openshift-logging mode",
 			opts: &Options{
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -94,6 +187,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -160,6 +258,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,
@@ -179,6 +282,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -234,6 +234,9 @@ func TestBuildGateway_HasExtraObjectsForTenantMode(t *testing.T) {
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
@@ -264,6 +267,9 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_RouteSvcMatches(t *testing.T
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
@@ -336,6 +342,9 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_ReplacesIngressWithRoute(t *
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{

--- a/operator/internal/manifests/openshift/build.go
+++ b/operator/internal/manifests/openshift/build.go
@@ -10,10 +10,19 @@ func BuildGatewayObjects(opts Options) []client.Object {
 	return []client.Object{
 		BuildRoute(opts),
 		BuildGatewayCAConfigMap(opts),
-		BuildGatewayClusterRole(opts),
-		BuildGatewayClusterRoleBinding(opts),
 		BuildMonitoringRole(opts),
 		BuildMonitoringRoleBinding(opts),
+	}
+}
+
+// BuildGatewayTenantModeObjects returns a list of auxiliary openshift/k8s objects
+// for lokistack gateway deployments on OpenShift for tenant modes:
+// - openshift-logging
+// - openshift-network
+func BuildGatewayTenantModeObjects(opts Options) []client.Object {
+	return []client.Object{
+		BuildGatewayClusterRole(opts),
+		BuildGatewayClusterRoleBinding(opts),
 	}
 }
 

--- a/operator/internal/manifests/openshift/build_test.go
+++ b/operator/internal/manifests/openshift/build_test.go
@@ -10,32 +10,33 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-func TestBuildGatewayObjects_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
+func TestBuildGatewayTenantModeObjects_ClusterRoleRefMatches(t *testing.T) {
+	opts := NewOptions("abc", "ns", "abc", "abc", "abc", map[string]string{}, "abc").
+		WithTenantsForMode(lokiv1.OpenshiftLogging, "example.com", map[string]TenantData{})
 
-	objs := BuildGatewayObjects(opts)
-	cr := objs[2].(*rbacv1.ClusterRole)
-	rb := objs[3].(*rbacv1.ClusterRoleBinding)
+	objs := BuildGatewayTenantModeObjects(*opts)
+	cr := objs[0].(*rbacv1.ClusterRole)
+	rb := objs[1].(*rbacv1.ClusterRoleBinding)
 
 	require.Equal(t, cr.Kind, rb.RoleRef.Kind)
 	require.Equal(t, cr.Name, rb.RoleRef.Name)
 }
 
 func TestBuildGatewayObjects_MonitoringClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
+	opts := NewOptions("abc", "ns", "abc", "abc", "abc", map[string]string{}, "abc")
 
-	objs := BuildGatewayObjects(opts)
-	cr := objs[4].(*rbacv1.Role)
-	rb := objs[5].(*rbacv1.RoleBinding)
+	objs := BuildGatewayObjects(*opts)
+	cr := objs[2].(*rbacv1.Role)
+	rb := objs[3].(*rbacv1.RoleBinding)
 
 	require.Equal(t, cr.Kind, rb.RoleRef.Kind)
 	require.Equal(t, cr.Name, rb.RoleRef.Name)
 }
 
 func TestBuildRulerObjects_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
+	opts := NewOptions("abc", "ns", "abc", "abc", "abc", map[string]string{}, "abc")
 
-	objs := BuildRulerObjects(opts)
+	objs := BuildRulerObjects(*opts)
 	sa := objs[1].(*corev1.ServiceAccount)
 	cr := objs[2].(*rbacv1.ClusterRole)
 	rb := objs[3].(*rbacv1.ClusterRoleBinding)

--- a/operator/internal/manifests/openshift/options.go
+++ b/operator/internal/manifests/openshift/options.go
@@ -54,16 +54,30 @@ type TenantData struct {
 
 // NewOptions returns an openshift options struct.
 func NewOptions(
-	mode lokiv1.ModeType,
 	stackName, stackNamespace string,
-	gwName, gwBaseDomain, gwSvcName, gwPortName string,
+	gwName, gwSvcName, gwPortName string,
 	gwLabels map[string]string,
-	tenantConfigMap map[string]TenantData,
 	rulerName string,
-) Options {
-	host := ingressHost(stackName, stackNamespace, gwBaseDomain)
+) *Options {
+	return &Options{
+		BuildOpts: BuildOptions{
+			LokiStackName:        stackName,
+			LokiStackNamespace:   stackNamespace,
+			GatewayName:          gwName,
+			GatewaySvcName:       gwSvcName,
+			GatewaySvcTargetPort: gwPortName,
+			Labels:               gwLabels,
+			RulerName:            rulerName,
+		},
+	}
+}
 
-	var authn []AuthenticationSpec
+func (o *Options) WithTenantsForMode(mode lokiv1.ModeType, gwBaseDomain string, tenantConfigMap map[string]TenantData) *Options {
+	var (
+		authn []AuthenticationSpec
+		authz AuthorizationSpec
+		host  = ingressHost(o.BuildOpts.LokiStackName, o.BuildOpts.LokiStackNamespace, gwBaseDomain)
+	)
 
 	tenants := GetTenants(mode)
 	for _, name := range tenants {
@@ -75,27 +89,22 @@ func NewOptions(
 		authn = append(authn, AuthenticationSpec{
 			TenantName:     name,
 			TenantID:       name,
-			ServiceAccount: gwName,
+			ServiceAccount: o.BuildOpts.GatewayName,
 			RedirectURL:    fmt.Sprintf("https://%s/openshift/%s/callback", host, name),
 			CookieSecret:   cookieSecret,
 		})
 	}
 
-	return Options{
-		BuildOpts: BuildOptions{
-			LokiStackName:        stackName,
-			LokiStackNamespace:   stackNamespace,
-			GatewayName:          gwName,
-			GatewaySvcName:       gwSvcName,
-			GatewaySvcTargetPort: gwPortName,
-			Labels:               gwLabels,
-			RulerName:            rulerName,
-		},
-		Authentication: authn,
-		Authorization: AuthorizationSpec{
+	if len(tenants) > 0 {
+		authz = AuthorizationSpec{
 			OPAUrl: fmt.Sprintf("http://localhost:%d/v1/data/%s/allow", GatewayOPAHTTPPort, opaDefaultPackage),
-		},
+		}
 	}
+
+	o.Authentication = authn
+	o.Authorization = authz
+
+	return o
 }
 
 func newCookieSecret() string {

--- a/operator/main.go
+++ b/operator/main.go
@@ -89,7 +89,7 @@ func main() {
 	if ctrlCfg.Gates.LokiStackGateway {
 		utilruntime.Must(configv1.AddToScheme(scheme))
 
-		if ctrlCfg.Gates.OpenShift.GatewayRoute {
+		if ctrlCfg.Gates.OpenShift.Enabled {
 			utilruntime.Must(routev1.AddToScheme(scheme))
 		}
 	}


### PR DESCRIPTION
The present PR is a backport of enabling the LokiStack Route resource by default on any OpenShift cluster (community and OCP).

Ref: [LOG-4139](https://issues.redhat.com//browse/LOG-4139)

/cc @xperimental
/assign @periklis
