### PR TITLE
[release-5.7] Backport PR grafana/loki#9405

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [9405](https://github.com/grafana/loki/pull/9405) **periklis**: Add support for configuring HTTP server timeouts
 - [9346](https://github.com/grafana/loki/pull/9346) **periklis**: Enable Route by default on OpenShift clusters
 - [9036](https://github.com/grafana/loki/pull/9036) **periklis**: Update Loki operand to v2.8.0
 - [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -545,7 +545,7 @@ type QueryLimitSpec struct {
 	//
 	// +optional
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:="1m"
+	// +kubebuilder:default:="3m"
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Query Timeout"
 	QueryTimeout string `json:"queryTimeout,omitempty"`
 }
@@ -854,6 +854,8 @@ const (
 	ReasonMissingGatewayOpenShiftBaseDomain LokiStackConditionReason = "MissingGatewayOpenShiftBaseDomain"
 	// ReasonFailedCertificateRotation when the reconciler cannot rotate any of the required TLS certificates.
 	ReasonFailedCertificateRotation LokiStackConditionReason = "FailedCertificateRotation"
+	// ReasonQueryTimeoutInvalid when the QueryTimeout can not be parsed.
+	ReasonQueryTimeoutInvalid LokiStackConditionReason = "ReasonQueryTimeoutInvalid"
 )
 
 // PodStatusMap defines the type for mapping pod status to pod name.

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-05-23T07:47:18Z"
+    createdAt: "2023-05-23T07:56:36Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -151,7 +151,7 @@ spec:
                             format: int32
                             type: integer
                           queryTimeout:
-                            default: 1m
+                            default: 3m
                             description: Timeout when querying ingesters or storage
                               during the execution of a query request.
                             type: string
@@ -264,7 +264,7 @@ spec:
                               format: int32
                               type: integer
                             queryTimeout:
-                              default: 1m
+                              default: 3m
                               description: Timeout when querying ingesters or storage
                                 during the execution of a query request.
                               type: string

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-05-23T07:47:15Z"
+    createdAt: "2023-05-23T07:56:34Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
@@ -151,7 +151,7 @@ spec:
                             format: int32
                             type: integer
                           queryTimeout:
-                            default: 1m
+                            default: 3m
                             description: Timeout when querying ingesters or storage
                               during the execution of a query request.
                             type: string
@@ -264,7 +264,7 @@ spec:
                               format: int32
                               type: integer
                             queryTimeout:
-                              default: 1m
+                              default: 3m
                               description: Timeout when querying ingesters or storage
                                 during the execution of a query request.
                               type: string

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2023-05-23T07:47:20Z"
+    createdAt: "2023-05-23T07:56:39Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -151,7 +151,7 @@ spec:
                             format: int32
                             type: integer
                           queryTimeout:
-                            default: 1m
+                            default: 3m
                             description: Timeout when querying ingesters or storage
                               during the execution of a query request.
                             type: string
@@ -264,7 +264,7 @@ spec:
                               format: int32
                               type: integer
                             queryTimeout:
-                              default: 1m
+                              default: 3m
                               description: Timeout when querying ingesters or storage
                                 during the execution of a query request.
                               type: string

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -134,7 +134,7 @@ spec:
                             format: int32
                             type: integer
                           queryTimeout:
-                            default: 1m
+                            default: 3m
                             description: Timeout when querying ingesters or storage
                               during the execution of a query request.
                             type: string
@@ -247,7 +247,7 @@ spec:
                               format: int32
                               type: integer
                             queryTimeout:
-                              default: 1m
+                              default: 3m
                               description: Timeout when querying ingesters or storage
                                 during the execution of a query request.
                               type: string

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -1553,6 +1553,9 @@ for the ruler is missing.</p>
 </tr><tr><td><p>&#34;PendingComponents&#34;</p></td>
 <td><p>ReasonPendingComponents when all/some LokiStack components pending dependencies</p>
 </td>
+</tr><tr><td><p>&#34;ReasonQueryTimeoutInvalid&#34;</p></td>
+<td><p>ReasonQueryTimeoutInvalid when the QueryTimeout can not be parsed.</p>
+</td>
 </tr><tr><td><p>&#34;ReadyComponents&#34;</p></td>
 <td><p>ReasonReadyComponents when all LokiStack components are ready to serve traffic.</p>
 </td>

--- a/operator/internal/handlers/lokistack_create_or_update.go
+++ b/operator/internal/handlers/lokistack_create_or_update.go
@@ -269,6 +269,16 @@ func CreateOrUpdateLokiStack(
 		certRotationRequiredAt = stack.Annotations[manifests.AnnotationCertRotationRequiredAt]
 	}
 
+	timeoutConfig, err := manifests.NewTimeoutConfig(stack.Spec.Limits)
+	if err != nil {
+		ll.Error(err, "failed to parse query timeout")
+		return &status.DegradedError{
+			Message: fmt.Sprintf("Error parsing query timeout: %s", err),
+			Reason:  lokiv1.ReasonQueryTimeoutInvalid,
+			Requeue: false,
+		}
+	}
+
 	// Here we will translate the lokiv1.LokiStack options into manifest options
 	opts := manifests.Options{
 		Name:                   req.Name,
@@ -286,6 +296,7 @@ func CreateOrUpdateLokiStack(
 			Spec:   rulerConfig,
 			Secret: rulerSecret,
 		},
+		Timeouts: timeoutConfig,
 		Tenants: manifests.Tenants{
 			Secrets: tenantSecrets,
 			Configs: tenantConfigs,

--- a/operator/internal/manifests/build_test.go
+++ b/operator/internal/manifests/build_test.go
@@ -35,6 +35,7 @@ func TestApplyUserOptions_OverrideDefaults(t *testing.T) {
 					},
 				},
 			},
+			Timeouts: defaultTimeoutConfig,
 		}
 		err := ApplyDefaultSettings(&opt)
 		defs := internal.StackSizeTable[size]
@@ -75,6 +76,7 @@ func TestApplyUserOptions_AlwaysSetCompactorReplicasToOne(t *testing.T) {
 					},
 				},
 			},
+			Timeouts: defaultTimeoutConfig,
 		}
 		err := ApplyDefaultSettings(&opt)
 		defs := internal.StackSizeTable[size]
@@ -229,6 +231,7 @@ func TestBuildAll_WithFeatureGates_ServiceMonitors(t *testing.T) {
 						ServingCertsService: false,
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 		{
@@ -247,6 +250,7 @@ func TestBuildAll_WithFeatureGates_ServiceMonitors(t *testing.T) {
 						ServingCertsService: false,
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 	}
@@ -289,6 +293,7 @@ func TestBuildAll_WithFeatureGates_OpenShift_ServingCertsService(t *testing.T) {
 						ServingCertsService: false,
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 		{
@@ -306,6 +311,7 @@ func TestBuildAll_WithFeatureGates_OpenShift_ServingCertsService(t *testing.T) {
 						ServingCertsService: true,
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 	}
@@ -346,6 +352,7 @@ func TestBuildAll_WithFeatureGates_HTTPEncryption(t *testing.T) {
 		Gates: configv1.FeatureGates{
 			HTTPEncryption: true,
 		},
+		Timeouts: defaultTimeoutConfig,
 	}
 
 	err := ApplyDefaultSettings(&opts)
@@ -419,6 +426,7 @@ func TestBuildAll_WithFeatureGates_ServiceMonitorTLSEndpoints(t *testing.T) {
 			HTTPEncryption:             true,
 			ServiceMonitorTLSEndpoints: true,
 		},
+		Timeouts: defaultTimeoutConfig,
 	}
 
 	err := ApplyDefaultSettings(&opts)
@@ -523,6 +531,7 @@ func TestBuildAll_WithFeatureGates_GRPCEncryption(t *testing.T) {
 				Gates: configv1.FeatureGates{
 					GRPCEncryption: false,
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 		{
@@ -565,6 +574,7 @@ func TestBuildAll_WithFeatureGates_GRPCEncryption(t *testing.T) {
 				Gates: configv1.FeatureGates{
 					GRPCEncryption: true,
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 	}
@@ -689,6 +699,7 @@ func TestBuildAll_WithFeatureGates_RuntimeSeccompProfile(t *testing.T) {
 				Gates: configv1.FeatureGates{
 					RuntimeSeccompProfile: false,
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 		{
@@ -731,6 +742,7 @@ func TestBuildAll_WithFeatureGates_RuntimeSeccompProfile(t *testing.T) {
 				Gates: configv1.FeatureGates{
 					RuntimeSeccompProfile: true,
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 	}
@@ -794,6 +806,7 @@ func TestBuildAll_WithFeatureGates_LokiStackGateway(t *testing.T) {
 					HTTPEncryption:             true,
 					ServiceMonitorTLSEndpoints: false,
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 		{
@@ -832,6 +845,7 @@ func TestBuildAll_WithFeatureGates_LokiStackGateway(t *testing.T) {
 					HTTPEncryption:             true,
 					ServiceMonitorTLSEndpoints: true,
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 	}
@@ -870,6 +884,7 @@ func TestBuildAll_WithFeatureGates_LokiStackAlerts(t *testing.T) {
 					ServiceMonitors: false,
 					LokiStackAlerts: false,
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 		{
@@ -884,6 +899,7 @@ func TestBuildAll_WithFeatureGates_LokiStackAlerts(t *testing.T) {
 					ServiceMonitors: true,
 					LokiStackAlerts: true,
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 		},
 	}

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -162,6 +162,7 @@ func ConfigOptions(opt Options) config.Options {
 			IngesterMemoryRequest: opt.ResourceRequirements.Ingester.Requests.Memory().Value(),
 		},
 		ObjectStorage:         opt.ObjectStorage,
+		HTTPTimeouts:          opt.Timeouts.Loki,
 		EnableRemoteReporting: opt.Gates.GrafanaLabsUsageReport,
 		Ruler: config.Ruler{
 			Enabled:               rulerEnabled,

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
@@ -39,11 +40,22 @@ func TestConfigOptions_UserOptionsTakePrecedence(t *testing.T) {
 	assert.JSONEq(t, string(expected), string(actual))
 }
 
+func testTimeoutConfig() TimeoutConfig {
+	return TimeoutConfig{
+		Loki: config.HTTPTimeoutConfig{
+			IdleTimeout:  1 * time.Second,
+			ReadTimeout:  1 * time.Minute,
+			WriteTimeout: 10 * time.Minute,
+		},
+	}
+}
+
 func randomConfigOptions() Options {
 	return Options{
 		Name:      uuid.New().String(),
 		Namespace: uuid.New().String(),
 		Image:     uuid.New().String(),
+		Timeouts:  testTimeoutConfig(),
 		Stack: lokiv1.LokiStackSpec{
 			Size:              lokiv1.SizeOneXExtraSmall,
 			Storage:           lokiv1.ObjectStorageSpec{},
@@ -252,6 +264,7 @@ func TestConfigOptions_GossipRingConfig(t *testing.T) {
 				Name:      "my-stack",
 				Namespace: "my-ns",
 				Stack:     tc.spec,
+				Timeouts:  testTimeoutConfig(),
 			}
 			options := ConfigOptions(inOpt)
 			require.Equal(t, tc.wantOptions, options.GossipRing)
@@ -357,7 +370,8 @@ func TestConfigOptions_RetentionConfig(t *testing.T) {
 			t.Parallel()
 
 			inOpt := Options{
-				Stack: tc.spec,
+				Stack:    tc.spec,
+				Timeouts: testTimeoutConfig(),
 			}
 			options := ConfigOptions(inOpt)
 			require.Equal(t, tc.wantOptions, options.Retention)
@@ -379,6 +393,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 						Mode: lokiv1.Static,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions: nil,
 		},
@@ -390,6 +405,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 						Mode: lokiv1.Dynamic,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions: nil,
 		},
@@ -401,6 +417,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 						Mode: lokiv1.OpenshiftLogging,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 				OpenShiftOptions: openshift.Options{
 					BuildOpts: openshift.BuildOptions{
 						AlertManagerEnabled: true,
@@ -422,6 +439,7 @@ func TestConfigOptions_RulerAlertManager(t *testing.T) {
 						Mode: lokiv1.OpenshiftNetwork,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 				OpenShiftOptions: openshift.Options{
 					BuildOpts: openshift.BuildOptions{
 						AlertManagerEnabled: true,
@@ -465,6 +483,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 						Mode: lokiv1.Static,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions: nil,
 		},
@@ -476,6 +495,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 						Mode: lokiv1.Dynamic,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions: nil,
 		},
@@ -490,6 +510,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 						Enabled: true,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
@@ -526,6 +547,7 @@ func TestConfigOptions_RulerAlertManager_UserOverride(t *testing.T) {
 						Enabled: true,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
@@ -580,6 +602,7 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 						Mode: lokiv1.Static,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions: nil,
 		},
@@ -591,6 +614,7 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 						Mode: lokiv1.Dynamic,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions: nil,
 		},
@@ -605,6 +629,7 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 						Enabled: true,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
@@ -658,6 +683,7 @@ func TestConfigOptions_RulerOverrides_OCPApplicationTenant(t *testing.T) {
 						Enabled: true,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
@@ -707,6 +733,7 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 						Mode: lokiv1.Static,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions: nil,
 		},
@@ -718,6 +745,7 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 						Mode: lokiv1.Dynamic,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions: nil,
 		},
@@ -732,6 +760,7 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 						Enabled: true,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
@@ -863,6 +892,7 @@ func TestConfigOptions_RulerOverrides(t *testing.T) {
 						Enabled: true,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
@@ -913,6 +943,7 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 						Mode: lokiv1.Static,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions:          nil,
 			wantOverridesOptions: nil,
@@ -925,6 +956,7 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 						Mode: lokiv1.Dynamic,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 			},
 			wantOptions:          nil,
 			wantOverridesOptions: nil,
@@ -940,6 +972,7 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 						Enabled: true,
 					},
 				},
+				Timeouts: testTimeoutConfig(),
 				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
@@ -999,6 +1032,8 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 						Enabled: true,
 					},
 				},
+
+				Timeouts: testTimeoutConfig(),
 				Ruler: Ruler{
 					Spec: &lokiv1.RulerConfigSpec{
 						AlertManagerSpec: &lokiv1.AlertManagerSpec{
@@ -1039,4 +1074,20 @@ func TestConfigOptions_RulerOverrides_OCPUserWorkloadOnlyEnabled(t *testing.T) {
 			require.EqualValues(t, tc.wantOptions, cfg.Ruler.AlertManager)
 		})
 	}
+}
+
+func TestConfigOptions_ServerOptions(t *testing.T) {
+	opt := Options{
+		Stack:    lokiv1.LokiStackSpec{},
+		Timeouts: testTimeoutConfig(),
+	}
+	got := ConfigOptions(opt)
+
+	want := config.HTTPTimeoutConfig{
+		IdleTimeout:  time.Second,
+		ReadTimeout:  time.Minute,
+		WriteTimeout: 10 * time.Minute,
+	}
+
+	require.Equal(t, want, got.HTTPTimeouts)
 }

--- a/operator/internal/manifests/gateway.go
+++ b/operator/internal/manifests/gateway.go
@@ -137,8 +137,11 @@ func NewGatewayDeployment(opts Options, sha1C string) *appsv1.Deployment {
 					fmt.Sprintf("--logs.read.endpoint=http://%s:%d", fqdn(serviceNameQueryFrontendHTTP(opts.Name), opts.Namespace), httpPort),
 					fmt.Sprintf("--logs.tail.endpoint=http://%s:%d", fqdn(serviceNameQueryFrontendHTTP(opts.Name), opts.Namespace), httpPort),
 					fmt.Sprintf("--logs.write.endpoint=http://%s:%d", fqdn(serviceNameDistributorHTTP(opts.Name), opts.Namespace), httpPort),
+					fmt.Sprintf("--logs.write-timeout=%s", opts.Timeouts.Gateway.UpstreamWriteTimeout),
 					fmt.Sprintf("--rbac.config=%s", path.Join(gateway.LokiGatewayMountDir, gateway.LokiGatewayRbacFileName)),
 					fmt.Sprintf("--tenants.config=%s", path.Join(gateway.LokiGatewayMountDir, gateway.LokiGatewayTenantFileName)),
+					fmt.Sprintf("--server.read-timeout=%s", opts.Timeouts.Gateway.ReadTimeout),
+					fmt.Sprintf("--server.write-timeout=%s", opts.Timeouts.Gateway.WriteTimeout),
 				},
 				Ports: []corev1.ContainerPort{
 					{

--- a/operator/internal/manifests/gateway_tenants.go
+++ b/operator/internal/manifests/gateway_tenants.go
@@ -3,12 +3,13 @@ package manifests
 import (
 	"github.com/ViaQ/logerr/v2/kverrors"
 
+	"github.com/imdario/mergo"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
 	configv1 "github.com/grafana/loki/operator/apis/config/v1"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	"github.com/grafana/loki/operator/internal/manifests/openshift"
-	"github.com/imdario/mergo"
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,7 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 		GatewayName(opts.Name),
 		serviceNameGatewayHTTP(opts.Name),
 		gatewayHTTPPortName,
+		opts.Timeouts.Gateway.WriteTimeout,
 		ComponentLabels(LabelGatewayComponent, opts.Name),
 		RulerName(opts.Name),
 	)

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	"path"
 	"testing"
+	"time"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/require"
@@ -58,6 +59,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						Mode: lokiv1.Static,
 					},
 				},
+				Timeouts: TimeoutConfig{
+					Gateway: GatewayTimeoutConfig{
+						WriteTimeout: 1 * time.Minute,
+					},
+				},
 			},
 			want: &Options{
 				Name:              "lokistack-ocp",
@@ -73,6 +79,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						Mode: lokiv1.Static,
 					},
 				},
+				Timeouts: TimeoutConfig{
+					Gateway: GatewayTimeoutConfig{
+						WriteTimeout: 1 * time.Minute,
+					},
+				},
 				OpenShiftOptions: openshift.Options{
 					BuildOpts: openshift.BuildOptions{
 						LokiStackName:        "lokistack-ocp",
@@ -80,6 +91,7 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						GatewayName:          "lokistack-ocp-gateway",
 						GatewaySvcName:       "lokistack-ocp-gateway-http",
 						GatewaySvcTargetPort: "public",
+						GatewayRouteTimeout:  75 * time.Second,
 						RulerName:            "lokistack-ocp-ruler",
 						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
 					},
@@ -119,6 +131,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						Mode: lokiv1.Dynamic,
 					},
 				},
+				Timeouts: TimeoutConfig{
+					Gateway: GatewayTimeoutConfig{
+						WriteTimeout: 1 * time.Minute,
+					},
+				},
 			},
 			want: &Options{
 				Name:              "lokistack-ocp",
@@ -134,6 +151,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						Mode: lokiv1.Dynamic,
 					},
 				},
+				Timeouts: TimeoutConfig{
+					Gateway: GatewayTimeoutConfig{
+						WriteTimeout: 1 * time.Minute,
+					},
+				},
 				OpenShiftOptions: openshift.Options{
 					BuildOpts: openshift.BuildOptions{
 						LokiStackName:        "lokistack-ocp",
@@ -141,6 +163,7 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						GatewayName:          "lokistack-ocp-gateway",
 						GatewaySvcName:       "lokistack-ocp-gateway-http",
 						GatewaySvcTargetPort: "public",
+						GatewayRouteTimeout:  75 * time.Second,
 						RulerName:            "lokistack-ocp-ruler",
 						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
 					},
@@ -163,6 +186,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						Mode: lokiv1.OpenshiftLogging,
 					},
 				},
+				Timeouts: TimeoutConfig{
+					Gateway: GatewayTimeoutConfig{
+						WriteTimeout: 1 * time.Minute,
+					},
+				},
 				Tenants: Tenants{
 					Configs: map[string]TenantConfig{
 						"application": {
@@ -197,6 +225,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						Mode: lokiv1.OpenshiftLogging,
 					},
 				},
+				Timeouts: TimeoutConfig{
+					Gateway: GatewayTimeoutConfig{
+						WriteTimeout: 1 * time.Minute,
+					},
+				},
 				Tenants: Tenants{
 					Configs: map[string]TenantConfig{
 						"application": {
@@ -223,6 +256,7 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						GatewayName:          "lokistack-ocp-gateway",
 						GatewaySvcName:       "lokistack-ocp-gateway-http",
 						GatewaySvcTargetPort: "public",
+						GatewayRouteTimeout:  75 * time.Second,
 						RulerName:            "lokistack-ocp-ruler",
 						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
 					},
@@ -268,6 +302,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						Mode: lokiv1.OpenshiftNetwork,
 					},
 				},
+				Timeouts: TimeoutConfig{
+					Gateway: GatewayTimeoutConfig{
+						WriteTimeout: 1 * time.Minute,
+					},
+				},
 				Tenants: Tenants{
 					Configs: map[string]TenantConfig{
 						"network": {
@@ -292,6 +331,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						Mode: lokiv1.OpenshiftNetwork,
 					},
 				},
+				Timeouts: TimeoutConfig{
+					Gateway: GatewayTimeoutConfig{
+						WriteTimeout: 1 * time.Minute,
+					},
+				},
 				Tenants: Tenants{
 					Configs: map[string]TenantConfig{
 						"network": {
@@ -308,6 +352,7 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 						GatewayName:          "lokistack-ocp-gateway",
 						GatewaySvcName:       "lokistack-ocp-gateway-http",
 						GatewaySvcTargetPort: "public",
+						GatewayRouteTimeout:  75 * time.Second,
 						RulerName:            "lokistack-ocp-ruler",
 						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
 					},

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -46,6 +46,7 @@ func TestNewGatewayDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
 				},
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	}, sha1C)
 
 	expected := "loki.grafana.com/config-hash"
@@ -93,6 +94,7 @@ func TestNewGatewayDeployment_HasNodeSelector(t *testing.T) {
 				},
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	}, "deadbeef")
 
 	require.Equal(t, dpl.Spec.Template.Spec.NodeSelector, selector)
@@ -127,6 +129,7 @@ func TestNewGatewayDeployment_HasTemplateCertRotationRequiredAtAnnotation(t *tes
 				},
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	}, sha1C)
 
 	expected := "loki.grafana.com/certRotationRequiredAt"
@@ -185,6 +188,7 @@ func TestGatewayConfigMap_ReturnsSHA1OfBinaryContents(t *testing.T) {
 				},
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 		Tenants: Tenants{
 			Secrets: []*TenantSecrets{
 				{
@@ -219,6 +223,7 @@ func TestBuildGateway_HasConfigForTenantMode(t *testing.T) {
 				Mode: lokiv1.OpenshiftLogging,
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	})
 
 	require.NoError(t, err)
@@ -255,6 +260,7 @@ func TestBuildGateway_HasExtraObjectsForTenantMode(t *testing.T) {
 				Mode: lokiv1.OpenshiftLogging,
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	})
 
 	require.NoError(t, err)
@@ -290,6 +296,7 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_RouteSvcMatches(t *testing.T
 				Mode: lokiv1.OpenshiftLogging,
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	})
 
 	require.NoError(t, err)
@@ -327,6 +334,7 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_ServiceAccountNameMatches(t 
 				Mode: lokiv1.OpenshiftLogging,
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	})
 
 	require.NoError(t, err)
@@ -365,6 +373,7 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_ReplacesIngressWithRoute(t *
 				Mode: lokiv1.OpenshiftLogging,
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	})
 
 	require.NoError(t, err)
@@ -430,6 +439,7 @@ func TestBuildGateway_WithTLSProfile(t *testing.T) {
 						},
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 			expectedArgs: []string{
 				"--tls.min-version=min-version",
@@ -460,6 +470,7 @@ func TestBuildGateway_WithTLSProfile(t *testing.T) {
 						Mode: lokiv1.Dynamic,
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 			expectedArgs: []string{
 				"--tls.min-version=min-version",
@@ -490,6 +501,7 @@ func TestBuildGateway_WithTLSProfile(t *testing.T) {
 						Mode: lokiv1.OpenshiftLogging,
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 			expectedArgs: []string{
 				"--tls.min-version=min-version",
@@ -561,6 +573,7 @@ func TestBuildGateway_WithRulesEnabled(t *testing.T) {
 						},
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 			missingArgs: []string{
 				"--logs.rules.endpoint=http://abcd-ruler-http.efgh.svc.cluster.local:3100",
@@ -610,6 +623,7 @@ func TestBuildGateway_WithRulesEnabled(t *testing.T) {
 						},
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 			wantArgs: []string{
 				"--logs.rules.endpoint=http://abcd-ruler-http.efgh.svc.cluster.local:3100",
@@ -637,6 +651,7 @@ func TestBuildGateway_WithRulesEnabled(t *testing.T) {
 						Mode: lokiv1.Dynamic,
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 			wantArgs: []string{
 				"--logs.rules.endpoint=http://abcd-ruler-http.efgh.svc.cluster.local:3100",
@@ -668,6 +683,7 @@ func TestBuildGateway_WithRulesEnabled(t *testing.T) {
 						Mode: lokiv1.OpenshiftLogging,
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 			wantArgs: []string{
 				"--logs.rules.endpoint=https://abcd-ruler-http.efgh.svc.cluster.local:3100",
@@ -699,6 +715,7 @@ func TestBuildGateway_WithRulesEnabled(t *testing.T) {
 						Mode: lokiv1.OpenshiftLogging,
 					},
 				},
+				Timeouts: defaultTimeoutConfig,
 			},
 			wantArgs: []string{
 				"--logs.rules.endpoint=https://abcd-ruler-http.efgh.svc.cluster.local:3100",
@@ -752,6 +769,7 @@ func TestBuildGateway_WithHTTPEncryption(t *testing.T) {
 				Authentication: []lokiv1.AuthenticationSpec{},
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	})
 
 	require.NoError(t, err)
@@ -771,8 +789,11 @@ func TestBuildGateway_WithHTTPEncryption(t *testing.T) {
 		"--logs.read.endpoint=https://abcd-query-frontend-http.efgh.svc.cluster.local:3100",
 		"--logs.tail.endpoint=https://abcd-query-frontend-http.efgh.svc.cluster.local:3100",
 		"--logs.write.endpoint=https://abcd-distributor-http.efgh.svc.cluster.local:3100",
+		"--logs.write-timeout=4m0s",
 		"--rbac.config=/etc/lokistack-gateway/rbac.yaml",
 		"--tenants.config=/etc/lokistack-gateway/tenants.yaml",
+		"--server.read-timeout=48s",
+		"--server.write-timeout=6m0s",
 		"--logs.rules.endpoint=https://abcd-ruler-http.efgh.svc.cluster.local:3100",
 		"--logs.rules.read-only=true",
 		"--tls.client-auth-type=NoClientCert",

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	configv1 "github.com/grafana/loki/operator/apis/config/v1"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
@@ -151,8 +152,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   log_level: info
 storage_config:
   boltdb_shipper:
@@ -244,6 +246,11 @@ overrides:
 			},
 		},
 		EnableRemoteReporting: true,
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
 	}
 	cfg, rCfg, err := Build(opts)
 	require.NoError(t, err)
@@ -392,8 +399,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   log_level: info
 storage_config:
   boltdb_shipper:
@@ -514,6 +522,11 @@ overrides:
 					EffectiveDate: "2020-10-01",
 				},
 			},
+		},
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
 		},
 	}
 	cfg, rCfg, err := Build(opts)
@@ -792,8 +805,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   log_level: info
 storage_config:
   boltdb_shipper:
@@ -932,6 +946,11 @@ overrides:
 			},
 		},
 		EnableRemoteReporting: true,
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
 	}
 	cfg, rCfg, err := Build(opts)
 	require.NoError(t, err)
@@ -1134,8 +1153,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   log_level: info
 storage_config:
   boltdb_shipper:
@@ -1275,6 +1295,11 @@ overrides:
 			},
 		},
 		EnableRemoteReporting: true,
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
 	}
 	cfg, rCfg, err := Build(opts)
 	require.NoError(t, err)
@@ -1490,8 +1515,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   log_level: info
 storage_config:
   boltdb_shipper:
@@ -1648,6 +1674,11 @@ overrides:
 			},
 		},
 		EnableRemoteReporting: true,
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
 	}
 	cfg, rCfg, err := Build(opts)
 	require.NoError(t, err)
@@ -1804,8 +1835,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   log_level: info
 storage_config:
   boltdb_shipper:
@@ -1965,6 +1997,11 @@ overrides:
 		Retention: RetentionOptions{
 			Enabled:           true,
 			DeleteWorkerCount: 50,
+		},
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
 		},
 	}
 	cfg, rCfg, err := Build(opts)
@@ -2194,8 +2231,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   log_level: info
 storage_config:
   boltdb_shipper:
@@ -2369,6 +2407,11 @@ overrides:
 			},
 		},
 		EnableRemoteReporting: true,
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
 	}
 	cfg, rCfg, err := Build(opts)
 	require.NoError(t, err)
@@ -2555,8 +2598,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   tls_min_version: VersionTLS12
   tls_cipher_suites: cipher1,cipher2
   http_tls_config:
@@ -2699,6 +2743,11 @@ overrides:
 			},
 		},
 		EnableRemoteReporting: true,
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
 	}
 	cfg, rCfg, err := Build(opts)
 	require.NoError(t, err)
@@ -2927,8 +2976,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   log_level: info
 storage_config:
   boltdb_shipper:
@@ -3179,6 +3229,11 @@ overrides:
 			},
 		},
 		EnableRemoteReporting: true,
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
 	}
 	cfg, rCfg, err := Build(opts)
 	require.NoError(t, err)
@@ -3329,8 +3384,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
   log_level: info
 storage_config:
   boltdb_shipper:
@@ -3423,6 +3479,11 @@ overrides:
 			},
 		},
 		EnableRemoteReporting: true,
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
 	}
 	cfg, rCfg, err := Build(opts)
 	require.NoError(t, err)

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -415,8 +415,9 @@ server:
   grpc_server_max_recv_msg_size: 104857600
   grpc_server_max_send_msg_size: 104857600
   http_listen_port: 3100
-  http_server_idle_timeout: 120s
-  http_server_write_timeout: 1m
+  http_server_idle_timeout: {{ .HTTPTimeouts.IdleTimeout }}
+  http_server_read_timeout: {{ .HTTPTimeouts.ReadTimeout }}
+  http_server_write_timeout: {{ .HTTPTimeouts.WriteTimeout }}
 {{- if or .Gates.HTTPEncryption .Gates.GRPCEncryption }}
   tls_min_version: {{ .TLS.MinTLSVersion }}
   tls_cipher_suites: {{ .TLS.CipherSuitesString }}

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	configv1 "github.com/grafana/loki/operator/apis/config/v1"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
@@ -30,6 +31,8 @@ type Options struct {
 	EnableRemoteReporting bool
 
 	ObjectStorage storage.Options
+
+	HTTPTimeouts HTTPTimeoutConfig
 
 	Retention RetentionOptions
 
@@ -65,6 +68,13 @@ type GossipRing struct {
 	BindPort int
 	// MembersDiscoveryAddr is required
 	MembersDiscoveryAddr string
+}
+
+// HTTPTimeoutConfig defines the HTTP server config options.
+type HTTPTimeoutConfig struct {
+	IdleTimeout  time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
 }
 
 // Ruler configuration

--- a/operator/internal/manifests/openshift/options.go
+++ b/operator/internal/manifests/openshift/options.go
@@ -3,6 +3,7 @@ package openshift
 import (
 	"fmt"
 	"math/rand"
+	"time"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 )
@@ -41,6 +42,7 @@ type BuildOptions struct {
 	GatewayName                     string
 	GatewaySvcName                  string
 	GatewaySvcTargetPort            string
+	GatewayRouteTimeout             time.Duration
 	RulerName                       string
 	Labels                          map[string]string
 	AlertManagerEnabled             bool
@@ -56,6 +58,7 @@ type TenantData struct {
 func NewOptions(
 	stackName, stackNamespace string,
 	gwName, gwSvcName, gwPortName string,
+	gwWriteTimeout time.Duration,
 	gwLabels map[string]string,
 	rulerName string,
 ) *Options {
@@ -66,6 +69,7 @@ func NewOptions(
 			GatewayName:          gwName,
 			GatewaySvcName:       gwSvcName,
 			GatewaySvcTargetPort: gwPortName,
+			GatewayRouteTimeout:  gwWriteTimeout + gatewayRouteTimeoutExtension,
 			Labels:               gwLabels,
 			RulerName:            rulerName,
 		},

--- a/operator/internal/manifests/openshift/route.go
+++ b/operator/internal/manifests/openshift/route.go
@@ -1,6 +1,8 @@
 package openshift
 
 import (
+	"fmt"
+
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -19,6 +21,9 @@ func BuildRoute(opts Options) client.Object {
 			Name:      routeName(opts),
 			Namespace: opts.BuildOpts.LokiStackNamespace,
 			Labels:    opts.BuildOpts.Labels,
+			Annotations: map[string]string{
+				annotationGatewayRouteTimeout: fmt.Sprintf("%.fs", opts.BuildOpts.GatewayRouteTimeout.Seconds()),
+			},
 		},
 		Spec: routev1.RouteSpec{
 			To: routev1.RouteTargetReference{

--- a/operator/internal/manifests/openshift/var.go
+++ b/operator/internal/manifests/openshift/var.go
@@ -2,6 +2,13 @@ package openshift
 
 import (
 	"fmt"
+	"time"
+)
+
+const (
+	annotationGatewayRouteTimeout = "haproxy.router.openshift.io/timeout"
+
+	gatewayRouteTimeoutExtension = 15 * time.Second
 )
 
 var (

--- a/operator/internal/manifests/options.go
+++ b/operator/internal/manifests/options.go
@@ -2,6 +2,9 @@ package manifests
 
 import (
 	"strings"
+	"time"
+
+	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 
 	configv1 "github.com/grafana/loki/operator/apis/config/v1"
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
@@ -34,9 +37,24 @@ type Options struct {
 
 	OpenShiftOptions openshift.Options
 
+	Timeouts TimeoutConfig
+
 	Tenants Tenants
 
 	TLSProfile TLSProfileSpec
+}
+
+// GatewayTimeoutConfig contains the http server configuration options for all Loki components.
+type GatewayTimeoutConfig struct {
+	ReadTimeout          time.Duration
+	WriteTimeout         time.Duration
+	UpstreamWriteTimeout time.Duration
+}
+
+// TimeoutConfig contains the server configuration options for all Loki components
+type TimeoutConfig struct {
+	Loki    config.HTTPTimeoutConfig
+	Gateway GatewayTimeoutConfig
 }
 
 // Tenants contains the configuration per tenant and secrets for authn/authz.
@@ -104,4 +122,68 @@ type TLSProfileSpec struct {
 // to a string of elements joined with a comma.
 func (o Options) TLSCipherSuites() string {
 	return strings.Join(o.TLSProfile.Ciphers, ",")
+}
+
+// NewTimeoutConfig creates a TimeoutConfig from the QueryTimeout values in the spec's limits.
+func NewTimeoutConfig(s *lokiv1.LimitsSpec) (TimeoutConfig, error) {
+	if s == nil {
+		return defaultTimeoutConfig, nil
+	}
+
+	if s.Global == nil && s.Tenants == nil {
+		return defaultTimeoutConfig, nil
+	}
+
+	queryTimeout := lokiDefaultQueryTimeout
+	if s.Global.QueryLimits != nil && s.Global.QueryLimits.QueryTimeout != "" {
+		var err error
+		globalQueryTimeout, err := time.ParseDuration(s.Global.QueryLimits.QueryTimeout)
+		if err != nil {
+			return TimeoutConfig{}, err
+		}
+
+		if globalQueryTimeout > queryTimeout {
+			queryTimeout = globalQueryTimeout
+		}
+	}
+
+	for _, tLimit := range s.Tenants {
+		if tLimit.QueryLimits == nil || tLimit.QueryLimits.QueryTimeout == "" {
+			continue
+		}
+
+		tenantQueryTimeout, err := time.ParseDuration(tLimit.QueryLimits.QueryTimeout)
+		if err != nil {
+			return TimeoutConfig{}, err
+		}
+
+		if tenantQueryTimeout > queryTimeout {
+			queryTimeout = tenantQueryTimeout
+		}
+	}
+
+	return calculateHTTPTimeouts(queryTimeout), nil
+}
+
+func calculateHTTPTimeouts(queryTimeout time.Duration) TimeoutConfig {
+	idleTimeout := lokiDefaultHTTPIdleTimeout
+	if queryTimeout < idleTimeout {
+		idleTimeout = queryTimeout
+	}
+
+	readTimeout := queryTimeout / 10
+	writeTimeout := queryTimeout + lokiQueryWriteDuration
+
+	return TimeoutConfig{
+		Loki: config.HTTPTimeoutConfig{
+			IdleTimeout:  idleTimeout,
+			ReadTimeout:  readTimeout,
+			WriteTimeout: writeTimeout,
+		},
+		Gateway: GatewayTimeoutConfig{
+			ReadTimeout:          readTimeout + gatewayReadDuration,
+			WriteTimeout:         writeTimeout + gatewayWriteDuration,
+			UpstreamWriteTimeout: writeTimeout,
+		},
+	}
 }

--- a/operator/internal/manifests/options_test.go
+++ b/operator/internal/manifests/options_test.go
@@ -1,0 +1,142 @@
+package manifests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/loki/operator/internal/manifests/internal/config"
+
+	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
+)
+
+func TestNewTimeoutConfig_ReturnsDefaults_WhenLimitsSpecEmpty(t *testing.T) {
+	s := lokiv1.LokiStack{}
+
+	got, err := NewTimeoutConfig(s.Spec.Limits)
+	require.NoError(t, err)
+	require.Equal(t, defaultTimeoutConfig, got)
+}
+
+func TestNewTimeoutConfig_ReturnsCustomConfig_WhenLimitsSpecNotEmpty(t *testing.T) {
+	s := lokiv1.LokiStack{
+		Spec: lokiv1.LokiStackSpec{
+			Limits: &lokiv1.LimitsSpec{
+				Global: &lokiv1.LimitsTemplateSpec{
+					QueryLimits: &lokiv1.QueryLimitSpec{
+						QueryTimeout: "10m",
+					},
+				},
+			},
+		},
+	}
+
+	got, err := NewTimeoutConfig(s.Spec.Limits)
+	require.NoError(t, err)
+
+	want := TimeoutConfig{
+		Loki: config.HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  1 * time.Minute,
+			WriteTimeout: 11 * time.Minute,
+		},
+		Gateway: GatewayTimeoutConfig{
+			ReadTimeout:          1*time.Minute + gatewayReadDuration,
+			WriteTimeout:         11*time.Minute + gatewayWriteDuration,
+			UpstreamWriteTimeout: 11 * time.Minute,
+		},
+	}
+
+	require.Equal(t, want, got)
+}
+
+func TestNewTimeoutConfig_ReturnsCustomConfig_WhenLimitsSpecNotEmpty_UseMaxTenantQueryTimeout(t *testing.T) {
+	s := lokiv1.LokiStack{
+		Spec: lokiv1.LokiStackSpec{
+			Limits: &lokiv1.LimitsSpec{
+				Global: &lokiv1.LimitsTemplateSpec{
+					QueryLimits: &lokiv1.QueryLimitSpec{
+						QueryTimeout: "10m",
+					},
+				},
+				Tenants: map[string]lokiv1.LimitsTemplateSpec{
+					"tenant-a": {
+						QueryLimits: &lokiv1.QueryLimitSpec{
+							QueryTimeout: "10m",
+						},
+					},
+					"tenant-b": {
+						QueryLimits: &lokiv1.QueryLimitSpec{
+							QueryTimeout: "20m",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := NewTimeoutConfig(s.Spec.Limits)
+	require.NoError(t, err)
+
+	want := TimeoutConfig{
+		Loki: config.HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  2 * time.Minute,
+			WriteTimeout: 21 * time.Minute,
+		},
+		Gateway: GatewayTimeoutConfig{
+			ReadTimeout:          2*time.Minute + gatewayReadDuration,
+			WriteTimeout:         21*time.Minute + gatewayWriteDuration,
+			UpstreamWriteTimeout: 21 * time.Minute,
+		},
+	}
+
+	require.Equal(t, want, got)
+}
+
+func TestNewTimeoutConfig_ReturnsDefaults_WhenGlobalQueryTimeoutParseError(t *testing.T) {
+	s := lokiv1.LokiStack{
+		Spec: lokiv1.LokiStackSpec{
+			Limits: &lokiv1.LimitsSpec{
+				Global: &lokiv1.LimitsTemplateSpec{
+					QueryLimits: &lokiv1.QueryLimitSpec{
+						QueryTimeout: "invalid",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := NewTimeoutConfig(s.Spec.Limits)
+	require.Error(t, err)
+}
+
+func TestNewTimeoutConfig_ReturnsDefaults_WhenTenantQueryTimeoutParseError(t *testing.T) {
+	s := lokiv1.LokiStack{
+		Spec: lokiv1.LokiStackSpec{
+			Limits: &lokiv1.LimitsSpec{
+				Global: &lokiv1.LimitsTemplateSpec{
+					QueryLimits: &lokiv1.QueryLimitSpec{
+						QueryTimeout: "10m",
+					},
+				},
+				Tenants: map[string]lokiv1.LimitsTemplateSpec{
+					"tenant-a": {
+						QueryLimits: &lokiv1.QueryLimitSpec{
+							QueryTimeout: "invalid",
+						},
+					},
+					"tenant-b": {
+						QueryLimits: &lokiv1.QueryLimitSpec{
+							QueryTimeout: "20m",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := NewTimeoutConfig(s.Spec.Limits)
+	require.Error(t, err)
+}

--- a/operator/internal/manifests/service_test.go
+++ b/operator/internal/manifests/service_test.go
@@ -54,6 +54,7 @@ func TestServicesMatchPorts(t *testing.T) {
 				},
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	}
 	sha1C := "deadbef"
 
@@ -183,6 +184,7 @@ func TestServicesMatchLabels(t *testing.T) {
 				},
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 	}
 	sha1C := "deadbef"
 
@@ -305,6 +307,7 @@ func TestServices_WithEncryption(t *testing.T) {
 				},
 			},
 		},
+		Timeouts: defaultTimeoutConfig,
 		TLSProfile: TLSProfileSpec{
 			MinTLSVersion: "VersionTLS12",
 			Ciphers:       []string{"cipher1", "cipher2"},

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/grafana/loki/operator/internal/manifests/openshift"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -103,7 +104,20 @@ const (
 	kubernetesNodeOSLinux = "linux"
 )
 
+const (
+	// lokiDefaultQueryTimeout contains the default query timeout. It should match the value mentioned in the CRD
+	// definition and also the default in the `sizes.go`.
+	lokiDefaultQueryTimeout    = 3 * time.Minute
+	lokiDefaultHTTPIdleTimeout = 30 * time.Second
+	lokiQueryWriteDuration     = 1 * time.Minute
+
+	gatewayReadDuration  = 30 * time.Second
+	gatewayWriteDuration = 2 * time.Minute
+)
+
 var (
+	defaultTimeoutConfig = calculateHTTPTimeouts(lokiDefaultQueryTimeout)
+
 	defaultConfigMapMode = int32(420)
 	volumeFileSystemMode = corev1.PersistentVolumeFilesystem
 )


### PR DESCRIPTION
The present PR is a backport of managing server timeouts based on query timeout CR settings.

Ref: [LOG-4052](https://issues.redhat.com//browse/LOG-4052)

Depends on: 
- openshift/loki/pull/140

/cc @xperimental
/assign @periklis

