### PR TITLE
[release-5.6] Backport PR grafana/loki#9346

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Main
 
+## Release 5.6.7
+
+- [9346](https://github.com/grafana/loki/pull/9346) **periklis**: Enable Route by default on OpenShift clusters
+
+## Release 5.6.6
+
 - [9036](https://github.com/grafana/loki/pull/9036) **periklis**: Update Loki operand to v2.8.0
 
 ## Release 5.6.5

--- a/operator/apis/config/v1/projectconfig_types.go
+++ b/operator/apis/config/v1/projectconfig_types.go
@@ -28,16 +28,14 @@ type BuiltInCertManagement struct {
 
 // OpenShiftFeatureGates is the supported set of all operator features gates on OpenShift.
 type OpenShiftFeatureGates struct {
+	// Enabled defines the flag to enable that these feature gates are used against OpenShift Container Platform releases.
+	Enabled bool `json:"enabled,omitempty"`
+
 	// ServingCertsService enables OpenShift service-ca annotations on the lokistack-gateway service only
 	// to use the in-platform CA and generate a TLS cert/key pair per service for
 	// in-cluster data-in-transit encryption.
 	// More details: https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/service-ca-certificates.html
 	ServingCertsService bool `json:"servingCertsService,omitempty"`
-
-	// GatewayRoute enables creating an OpenShift Route for the LokiStack
-	// gateway to expose the service to public internet access.
-	// More details: https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html
-	GatewayRoute bool `json:"gatewayRoute,omitempty"`
 
 	// ExtendedRuleValidation enables extended validation of AlertingRule and RecordingRule
 	// to enforce tenancy in an OpenShift context.

--- a/operator/bundle/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -53,8 +53,8 @@ data:
       # OpenShift feature gates
       #
       openshift:
+        enabled: true
         servingCertsService: true
-        gatewayRoute: true
         ruleExtendedValidation: true
         clusterTLSPolicy: true
         clusterProxy: true

--- a/operator/config/overlays/openshift/controller_manager_config.yaml
+++ b/operator/config/overlays/openshift/controller_manager_config.yaml
@@ -50,8 +50,8 @@ featureGates:
   # OpenShift feature gates
   #
   openshift:
+    enabled: true
     servingCertsService: true
-    gatewayRoute: true
     ruleExtendedValidation: true
     clusterTLSPolicy: true
     clusterProxy: true

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -213,7 +213,7 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 		bld = bld.Owns(&monitoringv1.PrometheusRule{}, updateOrDeleteOnlyPred)
 	}
 
-	if r.FeatureGates.OpenShift.GatewayRoute {
+	if r.FeatureGates.OpenShift.Enabled {
 		bld = bld.Owns(&routev1.Route{}, updateOrDeleteOnlyPred)
 	} else {
 		bld = bld.Owns(&networkingv1.Ingress{}, updateOrDeleteOnlyPred)

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -152,7 +152,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			ownCallsCount: 11,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
-					GatewayRoute: false,
+					Enabled: false,
 				},
 			},
 			pred: updateOrDeleteOnlyPred,
@@ -163,7 +163,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			ownCallsCount: 11,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
-					GatewayRoute: true,
+					Enabled: true,
 				},
 			},
 			pred: updateOrDeleteOnlyPred,

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -824,7 +824,7 @@ are degraded or the cluster cannot connect to object storage.</p>
 <td><p>ConditionFailed defines the condition that components in the Loki deployment failed to roll out.</p>
 </td>
 </tr><tr><td><p>&#34;Pending&#34;</p></td>
-<td><p>ConditionPending defines the conditioin that some or all components are in pending state.</p>
+<td><p>ConditionPending defines the condition that some or all components are in pending state.</p>
 </td>
 </tr><tr><td><p>&#34;Ready&#34;</p></td>
 <td><p>ConditionReady defines the condition that all components in the Loki deployment are ready.</p>
@@ -1692,7 +1692,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>Key is the data key of a ConfigMap containing a CA certificate.
-It needs to be in the same namespace as the LokiStack custom resource.</p>
+It needs to be in the same namespace as the LokiStack custom resource.
+If empty, it defaults to &ldquo;service-ca.crt&rdquo;.</p>
 </td>
 </tr>
 <tr>
@@ -1703,7 +1704,6 @@ string
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>CA is the name of a ConfigMap containing a CA certificate.
 It needs to be in the same namespace as the LokiStack custom resource.</p>
 </td>

--- a/operator/docs/operator/feature-gates.md
+++ b/operator/docs/operator/feature-gates.md
@@ -331,6 +331,17 @@ when using HTTPEncryption or GRPCEncryption.</p>
 <tbody>
 <tr>
 <td>
+<code>enabled</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Enabled defines the flag to enable that these feature gates are used against OpenShift Container Platform releases.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>servingCertsService</code><br/>
 <em>
 bool
@@ -341,19 +352,6 @@ bool
 to use the in-platform CA and generate a TLS cert/key pair per service for
 in-cluster data-in-transit encryption.
 More details: <a href="https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/service-ca-certificates.html">https://docs.openshift.com/container-platform/latest/security/certificate_types_descriptions/service-ca-certificates.html</a></p>
-</td>
-</tr>
-<tr>
-<td>
-<code>gatewayRoute</code><br/>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>GatewayRoute enables creating an OpenShift Route for the LokiStack
-gateway to expose the service to public internet access.
-More details: <a href="https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html">https://docs.openshift.com/container-platform/latest/networking/understanding-networking.html</a></p>
 </td>
 </tr>
 <tr>

--- a/operator/internal/manifests/gateway_tenants_test.go
+++ b/operator/internal/manifests/gateway_tenants_test.go
@@ -43,6 +43,50 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 			},
 		},
 		{
+			desc: "static mode on openshift",
+			opts: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Static,
+					},
+				},
+			},
+			want: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Static,
+					},
+				},
+				OpenShiftOptions: openshift.Options{
+					BuildOpts: openshift.BuildOptions{
+						LokiStackName:        "lokistack-ocp",
+						LokiStackNamespace:   "stack-ns",
+						GatewayName:          "lokistack-ocp-gateway",
+						GatewaySvcName:       "lokistack-ocp-gateway-http",
+						GatewaySvcTargetPort: "public",
+						RulerName:            "lokistack-ocp-ruler",
+						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
+					},
+				},
+			},
+		},
+		{
 			desc: "dynamic mode",
 			opts: &Options{
 				Stack: lokiv1.LokiStackSpec{
@@ -60,11 +104,60 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 			},
 		},
 		{
+			desc: "dynamic mode on openshift",
+			opts: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Dynamic,
+					},
+				},
+			},
+			want: &Options{
+				Name:              "lokistack-ocp",
+				Namespace:         "stack-ns",
+				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
+				Stack: lokiv1.LokiStackSpec{
+					Tenants: &lokiv1.TenantsSpec{
+						Mode: lokiv1.Dynamic,
+					},
+				},
+				OpenShiftOptions: openshift.Options{
+					BuildOpts: openshift.BuildOptions{
+						LokiStackName:        "lokistack-ocp",
+						LokiStackNamespace:   "stack-ns",
+						GatewayName:          "lokistack-ocp-gateway",
+						GatewaySvcName:       "lokistack-ocp-gateway-http",
+						GatewaySvcTargetPort: "public",
+						RulerName:            "lokistack-ocp-ruler",
+						Labels:               ComponentLabels(LabelGatewayComponent, "lokistack-ocp"),
+					},
+				},
+			},
+		},
+		{
 			desc: "openshift-logging mode",
 			opts: &Options{
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -94,6 +187,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftLogging,
@@ -160,6 +258,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,
@@ -179,6 +282,11 @@ func TestApplyGatewayDefaultsOptions(t *testing.T) {
 				Name:              "lokistack-ocp",
 				Namespace:         "stack-ns",
 				GatewayBaseDomain: "example.com",
+				Gates: configv1.FeatureGates{
+					OpenShift: configv1.OpenShiftFeatureGates{
+						Enabled: true,
+					},
+				},
 				Stack: lokiv1.LokiStackSpec{
 					Tenants: &lokiv1.TenantsSpec{
 						Mode: lokiv1.OpenshiftNetwork,

--- a/operator/internal/manifests/gateway_test.go
+++ b/operator/internal/manifests/gateway_test.go
@@ -234,6 +234,9 @@ func TestBuildGateway_HasExtraObjectsForTenantMode(t *testing.T) {
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
@@ -264,6 +267,9 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_RouteSvcMatches(t *testing.T
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{
@@ -336,6 +342,9 @@ func TestBuildGateway_WithExtraObjectsForTenantMode_ReplacesIngressWithRoute(t *
 		Namespace: "efgh",
 		Gates: configv1.FeatureGates{
 			LokiStackGateway: true,
+			OpenShift: configv1.OpenShiftFeatureGates{
+				Enabled: true,
+			},
 		},
 		OpenShiftOptions: openshift.Options{
 			BuildOpts: openshift.BuildOptions{

--- a/operator/internal/manifests/openshift/build.go
+++ b/operator/internal/manifests/openshift/build.go
@@ -10,10 +10,19 @@ func BuildGatewayObjects(opts Options) []client.Object {
 	return []client.Object{
 		BuildRoute(opts),
 		BuildGatewayCAConfigMap(opts),
-		BuildGatewayClusterRole(opts),
-		BuildGatewayClusterRoleBinding(opts),
 		BuildMonitoringRole(opts),
 		BuildMonitoringRoleBinding(opts),
+	}
+}
+
+// BuildGatewayTenantModeObjects returns a list of auxiliary openshift/k8s objects
+// for lokistack gateway deployments on OpenShift for tenant modes:
+// - openshift-logging
+// - openshift-network
+func BuildGatewayTenantModeObjects(opts Options) []client.Object {
+	return []client.Object{
+		BuildGatewayClusterRole(opts),
+		BuildGatewayClusterRoleBinding(opts),
 	}
 }
 

--- a/operator/internal/manifests/openshift/build_test.go
+++ b/operator/internal/manifests/openshift/build_test.go
@@ -10,32 +10,33 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
-func TestBuildGatewayObjects_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
+func TestBuildGatewayTenantModeObjects_ClusterRoleRefMatches(t *testing.T) {
+	opts := NewOptions("abc", "ns", "abc", "abc", "abc", map[string]string{}, "abc").
+		WithTenantsForMode(lokiv1.OpenshiftLogging, "example.com", map[string]TenantData{})
 
-	objs := BuildGatewayObjects(opts)
-	cr := objs[2].(*rbacv1.ClusterRole)
-	rb := objs[3].(*rbacv1.ClusterRoleBinding)
+	objs := BuildGatewayTenantModeObjects(*opts)
+	cr := objs[0].(*rbacv1.ClusterRole)
+	rb := objs[1].(*rbacv1.ClusterRoleBinding)
 
 	require.Equal(t, cr.Kind, rb.RoleRef.Kind)
 	require.Equal(t, cr.Name, rb.RoleRef.Name)
 }
 
 func TestBuildGatewayObjects_MonitoringClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
+	opts := NewOptions("abc", "ns", "abc", "abc", "abc", map[string]string{}, "abc")
 
-	objs := BuildGatewayObjects(opts)
-	cr := objs[4].(*rbacv1.Role)
-	rb := objs[5].(*rbacv1.RoleBinding)
+	objs := BuildGatewayObjects(*opts)
+	cr := objs[2].(*rbacv1.Role)
+	rb := objs[3].(*rbacv1.RoleBinding)
 
 	require.Equal(t, cr.Kind, rb.RoleRef.Kind)
 	require.Equal(t, cr.Name, rb.RoleRef.Name)
 }
 
 func TestBuildRulerObjects_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions(lokiv1.OpenshiftLogging, "abc", "ns", "abc", "example.com", "abc", "abc", map[string]string{}, map[string]TenantData{}, "abc")
+	opts := NewOptions("abc", "ns", "abc", "abc", "abc", map[string]string{}, "abc")
 
-	objs := BuildRulerObjects(opts)
+	objs := BuildRulerObjects(*opts)
 	sa := objs[1].(*corev1.ServiceAccount)
 	cr := objs[2].(*rbacv1.ClusterRole)
 	rb := objs[3].(*rbacv1.ClusterRoleBinding)

--- a/operator/internal/manifests/openshift/options.go
+++ b/operator/internal/manifests/openshift/options.go
@@ -53,16 +53,30 @@ type TenantData struct {
 
 // NewOptions returns an openshift options struct.
 func NewOptions(
-	mode lokiv1.ModeType,
 	stackName, stackNamespace string,
-	gwName, gwBaseDomain, gwSvcName, gwPortName string,
+	gwName, gwSvcName, gwPortName string,
 	gwLabels map[string]string,
-	tenantConfigMap map[string]TenantData,
 	rulerName string,
-) Options {
-	host := ingressHost(stackName, stackNamespace, gwBaseDomain)
+) *Options {
+	return &Options{
+		BuildOpts: BuildOptions{
+			LokiStackName:        stackName,
+			LokiStackNamespace:   stackNamespace,
+			GatewayName:          gwName,
+			GatewaySvcName:       gwSvcName,
+			GatewaySvcTargetPort: gwPortName,
+			Labels:               gwLabels,
+			RulerName:            rulerName,
+		},
+	}
+}
 
-	var authn []AuthenticationSpec
+func (o *Options) WithTenantsForMode(mode lokiv1.ModeType, gwBaseDomain string, tenantConfigMap map[string]TenantData) *Options {
+	var (
+		authn []AuthenticationSpec
+		authz AuthorizationSpec
+		host  = ingressHost(o.BuildOpts.LokiStackName, o.BuildOpts.LokiStackNamespace, gwBaseDomain)
+	)
 
 	tenants := GetTenants(mode)
 	for _, name := range tenants {
@@ -74,27 +88,22 @@ func NewOptions(
 		authn = append(authn, AuthenticationSpec{
 			TenantName:     name,
 			TenantID:       name,
-			ServiceAccount: gwName,
+			ServiceAccount: o.BuildOpts.GatewayName,
 			RedirectURL:    fmt.Sprintf("https://%s/openshift/%s/callback", host, name),
 			CookieSecret:   cookieSecret,
 		})
 	}
 
-	return Options{
-		BuildOpts: BuildOptions{
-			LokiStackName:        stackName,
-			LokiStackNamespace:   stackNamespace,
-			GatewayName:          gwName,
-			GatewaySvcName:       gwSvcName,
-			GatewaySvcTargetPort: gwPortName,
-			Labels:               gwLabels,
-			RulerName:            rulerName,
-		},
-		Authentication: authn,
-		Authorization: AuthorizationSpec{
+	if len(tenants) > 0 {
+		authz = AuthorizationSpec{
 			OPAUrl: fmt.Sprintf("http://localhost:%d/v1/data/%s/allow", GatewayOPAHTTPPort, opaDefaultPackage),
-		},
+		}
 	}
+
+	o.Authentication = authn
+	o.Authorization = authz
+
+	return o
 }
 
 func newCookieSecret() string {

--- a/operator/main.go
+++ b/operator/main.go
@@ -89,7 +89,7 @@ func main() {
 	if ctrlCfg.Gates.LokiStackGateway {
 		utilruntime.Must(configv1.AddToScheme(scheme))
 
-		if ctrlCfg.Gates.OpenShift.GatewayRoute {
+		if ctrlCfg.Gates.OpenShift.Enabled {
 			utilruntime.Must(routev1.AddToScheme(scheme))
 		}
 	}


### PR DESCRIPTION
The present PR is a backport of enabling the LokiStack Route resource by default on any OpenShift cluster (community and OCP).

Ref: [LOG-4140](https://issues.redhat.com//browse/LOG-4140)

/cc @xperimental
/assign @periklis