### PR TITLE
[release-5.7] Include runtime-config in compiling the SHA1 checksum

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+- [9448](https://github.com/grafana/loki/pull/9448) **btaani**: Include runtime-config in compiling the SHA1 checksum
 - [9511](https://github.com/grafana/loki/pull/9511) **xperimental**: Do not update status after setting degraded condition
 - [9405](https://github.com/grafana/loki/pull/9405) **periklis**: Add support for configuring HTTP server timeouts
 - [9346](https://github.com/grafana/loki/pull/9346) **periklis**: Enable Route by default on OpenShift clusters

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -32,6 +32,10 @@ func LokiConfigMap(opt Options) (*corev1.ConfigMap, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
+	_, err = s.Write(rc)
+	if err != nil {
+		return nil, "", err
+	}
 	sha1C := fmt.Sprintf("%x", s.Sum(nil))
 
 	return &corev1.ConfigMap{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a backport for fixing runtime-config SHA1 compilation to release-5.7

**Which issue(s) this PR fixes**:
Fixes [LOG-4161](https://issues.redhat.com/browse/LOG-4161) - Updating the RulerConfig CR can now trigger the restart of the ruler pod (and thus reflecting the changes to the user-workload AM)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [x] `CHANGELOG.md` updated
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/upgrading/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
