### PR TITLE
[release-5.7] Backport PR grafana/loki#9623

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,8 +1,16 @@
 ## Main
 
+## Release 5.7.2
+
+- [9623](https://github.com/grafana/loki/pull/9623) **periklis**: Fix timeout config constructor when only tenants limits
 - [9448](https://github.com/grafana/loki/pull/9448) **btaani**: Include runtime-config in compiling the SHA1 checksum
 - [9511](https://github.com/grafana/loki/pull/9511) **xperimental**: Do not update status after setting degraded condition
 - [9405](https://github.com/grafana/loki/pull/9405) **periklis**: Add support for configuring HTTP server timeouts
+
+## Release 5.7.1
+
+## Release 5.7.0
+
 - [9346](https://github.com/grafana/loki/pull/9346) **periklis**: Enable Route by default on OpenShift clusters
 - [9036](https://github.com/grafana/loki/pull/9036) **periklis**: Update Loki operand to v2.8.0
 - [8978](https://github.com/grafana/loki/pull/8978) **aminesnow**: Add watch for the object storage secret

--- a/operator/internal/manifests/options.go
+++ b/operator/internal/manifests/options.go
@@ -135,7 +135,7 @@ func NewTimeoutConfig(s *lokiv1.LimitsSpec) (TimeoutConfig, error) {
 	}
 
 	queryTimeout := lokiDefaultQueryTimeout
-	if s.Global.QueryLimits != nil && s.Global.QueryLimits.QueryTimeout != "" {
+	if s.Global != nil && s.Global.QueryLimits != nil && s.Global.QueryLimits.QueryTimeout != "" {
 		var err error
 		globalQueryTimeout, err := time.ParseDuration(s.Global.QueryLimits.QueryTimeout)
 		if err != nil {


### PR DESCRIPTION
Description:

The present PR is a backport for `release-5.7` of the fix for a nil-pointer dereference in the timeout config constructor

Ref: [LOG-4198](https://issues.redhat.com//browse/LOG-4198)

/cc @xperimental 
