### PR TITLE
[release-5.6] Backport PR grafana/loki#9623

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.7
 
+- [9623](https://github.com/grafana/loki/pull/9623) **periklis**: Fix timeout config constructor when only tenants limits
 - [9511](https://github.com/grafana/loki/pull/9511) **xperimental**: Do not update status after setting degraded condition
 - [9405](https://github.com/grafana/loki/pull/9405) **periklis**: Add support for configuring HTTP server timeouts
 - [9346](https://github.com/grafana/loki/pull/9346) **periklis**: Enable Route by default on OpenShift clusters

--- a/operator/internal/manifests/options.go
+++ b/operator/internal/manifests/options.go
@@ -135,7 +135,7 @@ func NewTimeoutConfig(s *lokiv1.LimitsSpec) (TimeoutConfig, error) {
 	}
 
 	queryTimeout := lokiDefaultQueryTimeout
-	if s.Global.QueryLimits != nil && s.Global.QueryLimits.QueryTimeout != "" {
+	if s.Global != nil && s.Global.QueryLimits != nil && s.Global.QueryLimits.QueryTimeout != "" {
 		var err error
 		globalQueryTimeout, err := time.ParseDuration(s.Global.QueryLimits.QueryTimeout)
 		if err != nil {


### PR DESCRIPTION
Description:

The present PR is a backport for `release-5.6` of the fix for a nil-pointer dereference in the timeout config constructor.

Ref: LOG-4199

/cc @xperimental 
