### PR TITLE
[release-5.7] Backport PR grafana/loki#9630

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Release 5.7.3
 
 - [9830](https://github.com/grafana/loki/pull/9830) **periklis**: Expose limits config setting cardinality_limit
+- [9630](https://github.com/grafana/loki/pull/9630) **jpinsonneau**: Expose per_stream_rate_limit & burst
 
 ## Release 5.7.2
 

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -613,6 +613,20 @@ type IngestionLimitSpec struct {
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number",displayName="Max Line Size"
 	MaxLineSize int32 `json:"maxLineSize,omitempty"`
+
+	// PerStreamRateLimit defines the maximum byte rate per second per stream. Units MB.
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number",displayName="Maximum byte rate per second per stream (in MB)"
+	PerStreamRateLimit int32 `json:"perStreamRateLimit,omitempty"`
+
+	// PerStreamRateLimitBurst defines the maximum burst bytes per stream. Units MB.
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:number",displayName="Maximum burst bytes per stream (in MB)"
+	PerStreamRateLimitBurst int32 `json:"perStreamRateLimitBurst,omitempty"`
 }
 
 // RetentionStreamSpec defines a log stream with separate retention time.

--- a/operator/apis/loki/v1beta1/lokistack_types_test.go
+++ b/operator/apis/loki/v1beta1/lokistack_types_test.go
@@ -379,6 +379,8 @@ func TestConvertToV1_LokiStack(t *testing.T) {
 								MaxLabelNamesPerSeries:    1000,
 								MaxGlobalStreamsPerTenant: 10000,
 								MaxLineSize:               512,
+								PerStreamRateLimit:        10,
+								PerStreamRateLimitBurst:   20,
 							},
 							QueryLimits: &v1.QueryLimitSpec{
 								MaxEntriesLimitPerQuery: 1000,
@@ -396,6 +398,8 @@ func TestConvertToV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -412,6 +416,8 @@ func TestConvertToV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -704,6 +710,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 								MaxLabelNamesPerSeries:    1000,
 								MaxGlobalStreamsPerTenant: 10000,
 								MaxLineSize:               512,
+								PerStreamRateLimit:        10,
+								PerStreamRateLimitBurst:   20,
 							},
 							QueryLimits: &v1.QueryLimitSpec{
 								MaxEntriesLimitPerQuery: 1000,
@@ -721,6 +729,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -737,6 +747,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -1001,6 +1013,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 								MaxLabelNamesPerSeries:    1000,
 								MaxGlobalStreamsPerTenant: 10000,
 								MaxLineSize:               512,
+								PerStreamRateLimit:        10,
+								PerStreamRateLimitBurst:   20,
 							},
 							QueryLimits: &v1beta1.QueryLimitSpec{
 								MaxEntriesLimitPerQuery: 1000,
@@ -1018,6 +1032,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1beta1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,
@@ -1034,6 +1050,8 @@ func TestConvertFromV1_LokiStack(t *testing.T) {
 									MaxLabelNamesPerSeries:    1000,
 									MaxGlobalStreamsPerTenant: 10000,
 									MaxLineSize:               512,
+									PerStreamRateLimit:        10,
+									PerStreamRateLimitBurst:   20,
 								},
 								QueryLimits: &v1beta1.QueryLimitSpec{
 									MaxEntriesLimitPerQuery: 1000,

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-06-30T04:22:21Z"
+    createdAt: "2023-06-30T07:14:33Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -329,6 +329,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.
         displayName: Cardinality Limit
         path: limits.global.queries.cardinalityLimit
@@ -399,6 +411,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.

--- a/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community-openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -130,6 +130,16 @@ spec:
                               on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
+                          perStreamRateLimit:
+                            description: PerStreamRateLimit defines the maximum byte
+                              rate per second per stream. Units MB.
+                            format: int32
+                            type: integer
+                          perStreamRateLimitBurst:
+                            description: PerStreamRateLimitBurst defines the maximum
+                              burst bytes per stream. Units MB.
+                            format: int32
+                            type: integer
                         type: object
                       queries:
                         description: QueryLimits defines the limit applied on querying
@@ -245,6 +255,16 @@ spec:
                             maxLineSize:
                               description: MaxLineSize defines the maximum line size
                                 on ingestion path. Units in Bytes.
+                              format: int32
+                              type: integer
+                            perStreamRateLimit:
+                              description: PerStreamRateLimit defines the maximum
+                                byte rate per second per stream. Units MB.
+                              format: int32
+                              type: integer
+                            perStreamRateLimitBurst:
+                              description: PerStreamRateLimitBurst defines the maximum
+                                burst bytes per stream. Units MB.
                               format: int32
                               type: integer
                           type: object

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-06-30T04:22:18Z"
+    createdAt: "2023-06-30T07:14:31Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -329,6 +329,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.
         displayName: Cardinality Limit
         path: limits.global.queries.cardinalityLimit
@@ -399,6 +411,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.

--- a/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/community/manifests/loki.grafana.com_lokistacks.yaml
@@ -130,6 +130,16 @@ spec:
                               on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
+                          perStreamRateLimit:
+                            description: PerStreamRateLimit defines the maximum byte
+                              rate per second per stream. Units MB.
+                            format: int32
+                            type: integer
+                          perStreamRateLimitBurst:
+                            description: PerStreamRateLimitBurst defines the maximum
+                              burst bytes per stream. Units MB.
+                            format: int32
+                            type: integer
                         type: object
                       queries:
                         description: QueryLimits defines the limit applied on querying
@@ -245,6 +255,16 @@ spec:
                             maxLineSize:
                               description: MaxLineSize defines the maximum line size
                                 on ingestion path. Units in Bytes.
+                              format: int32
+                              type: integer
+                            perStreamRateLimit:
+                              description: PerStreamRateLimit defines the maximum
+                                byte rate per second per stream. Units MB.
+                              format: int32
+                              type: integer
+                            perStreamRateLimitBurst:
+                              description: PerStreamRateLimitBurst defines the maximum
+                                burst bytes per stream. Units MB.
                               format: int32
                               type: integer
                           type: object

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2023-06-30T04:22:23Z"
+    createdAt: "2023-06-30T07:14:36Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -342,6 +342,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.
         displayName: Cardinality Limit
         path: limits.global.queries.cardinalityLimit
@@ -412,6 +424,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.

--- a/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -130,6 +130,16 @@ spec:
                               on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
+                          perStreamRateLimit:
+                            description: PerStreamRateLimit defines the maximum byte
+                              rate per second per stream. Units MB.
+                            format: int32
+                            type: integer
+                          perStreamRateLimitBurst:
+                            description: PerStreamRateLimitBurst defines the maximum
+                              burst bytes per stream. Units MB.
+                            format: int32
+                            type: integer
                         type: object
                       queries:
                         description: QueryLimits defines the limit applied on querying
@@ -245,6 +255,16 @@ spec:
                             maxLineSize:
                               description: MaxLineSize defines the maximum line size
                                 on ingestion path. Units in Bytes.
+                              format: int32
+                              type: integer
+                            perStreamRateLimit:
+                              description: PerStreamRateLimit defines the maximum
+                                byte rate per second per stream. Units MB.
+                              format: int32
+                              type: integer
+                            perStreamRateLimitBurst:
+                              description: PerStreamRateLimitBurst defines the maximum
+                                burst bytes per stream. Units MB.
                               format: int32
                               type: integer
                           type: object

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -113,6 +113,16 @@ spec:
                               on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
+                          perStreamRateLimit:
+                            description: PerStreamRateLimit defines the maximum byte
+                              rate per second per stream. Units MB.
+                            format: int32
+                            type: integer
+                          perStreamRateLimitBurst:
+                            description: PerStreamRateLimitBurst defines the maximum
+                              burst bytes per stream. Units MB.
+                            format: int32
+                            type: integer
                         type: object
                       queries:
                         description: QueryLimits defines the limit applied on querying
@@ -228,6 +238,16 @@ spec:
                             maxLineSize:
                               description: MaxLineSize defines the maximum line size
                                 on ingestion path. Units in Bytes.
+                              format: int32
+                              type: integer
+                            perStreamRateLimit:
+                              description: PerStreamRateLimit defines the maximum
+                                byte rate per second per stream. Units MB.
+                              format: int32
+                              type: integer
+                            perStreamRateLimitBurst:
+                              description: PerStreamRateLimitBurst defines the maximum
+                                burst bytes per stream. Units MB.
                               format: int32
                               type: integer
                           type: object

--- a/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -242,6 +242,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.
         displayName: Cardinality Limit
         path: limits.global.queries.cardinalityLimit
@@ -312,6 +324,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.

--- a/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community/bases/loki-operator.clusterserviceversion.yaml
@@ -242,6 +242,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.
         displayName: Cardinality Limit
         path: limits.global.queries.cardinalityLimit
@@ -312,6 +324,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.

--- a/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -254,6 +254,18 @@ spec:
         path: limits.global.ingestion.maxLineSize
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.global.ingestion.perStreamRateLimitBurst
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.
         displayName: Cardinality Limit
         path: limits.global.queries.cardinalityLimit
@@ -324,6 +336,18 @@ spec:
           Units in Bytes.
         displayName: Max Line Size
         path: limits.tenants.ingestion.maxLineSize
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimit defines the maximum byte rate per second per
+          stream. Units MB.
+        displayName: Maximum byte rate per second per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimit
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:number
+      - description: PerStreamRateLimitBurst defines the maximum burst bytes per stream.
+          Units MB.
+        displayName: Maximum burst bytes per stream (in MB)
+        path: limits.tenants.ingestion.perStreamRateLimitBurst
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:number
       - description: CardinalityLimit defines the cardinality limit for index queries.

--- a/operator/docs/lokistack/sop.md
+++ b/operator/docs/lokistack/sop.md
@@ -202,6 +202,8 @@ A service(s) is rate limiting at least 10% of all incoming requests.
 | `label_value_too_long` | `maxLabelValueLength` |
 | `line_too_long` | `maxLineSize` |
 | `max_label_names_per_series` | `maxLabelNamesPerSeries` |
+| `per_stream_rate_limit` | `perStreamRateLimit`, `perStreamRateLimitBurst` |
+
 
 ## Loki Storage Slow Write
 

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -1112,6 +1112,30 @@ int32
 <p>MaxLineSize defines the maximum line size on ingestion path. Units in Bytes.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>perStreamRateLimit</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PerStreamRateLimit defines the maximum byte rate per second per stream. Units MB.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>perStreamRateLimitBurst</code><br/>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PerStreamRateLimitBurst defines the maximum burst bytes per stream. Units MB.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -71,6 +71,8 @@ func randomConfigOptions() Options {
 						MaxLabelNamesPerSeries:    rand.Int31(),
 						MaxGlobalStreamsPerTenant: rand.Int31(),
 						MaxLineSize:               rand.Int31(),
+						PerStreamRateLimit:        rand.Int31(),
+						PerStreamRateLimitBurst:   rand.Int31(),
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: rand.Int31(),
@@ -88,6 +90,8 @@ func randomConfigOptions() Options {
 							MaxLabelNamesPerSeries:    rand.Int31(),
 							MaxGlobalStreamsPerTenant: rand.Int31(),
 							MaxLineSize:               rand.Int31(),
+							PerStreamRateLimit:        rand.Int31(),
+							PerStreamRateLimitBurst:   rand.Int31(),
 						},
 						QueryLimits: &lokiv1.QueryLimitSpec{
 							MaxEntriesLimitPerQuery: rand.Int31(),

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -187,6 +187,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -440,6 +442,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -551,6 +555,8 @@ func TestBuild_ConfigAndRuntimeConfig_CreateLokiConfigFailed(t *testing.T) {
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					// making it nil so that the template is not generated and error is returned
 					QueryLimits: nil,
@@ -842,6 +848,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -1191,6 +1199,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -1554,6 +1564,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -1885,6 +1897,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -2272,6 +2286,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -2660,6 +2676,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -3047,6 +3065,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,
@@ -3428,6 +3448,8 @@ overrides:
 						MaxLabelNamesPerSeries:    30,
 						MaxGlobalStreamsPerTenant: 0,
 						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
 					},
 					QueryLimits: &lokiv1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: 5000,

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -170,8 +170,8 @@ limits_config:
 {{- end }}
 {{- end }}{{- end }}
   max_cache_freshness_per_query: 10m
-  per_stream_rate_limit: 3MB
-  per_stream_rate_limit_burst: 15MB
+  per_stream_rate_limit: {{ .Stack.Limits.Global.IngestionLimits.PerStreamRateLimit }}MB
+  per_stream_rate_limit_burst: {{ .Stack.Limits.Global.IngestionLimits.PerStreamRateLimitBurst }}MB
   split_queries_by_interval: 30m
 {{- with .GossipRing }}
 memberlist:

--- a/operator/internal/manifests/internal/config/loki-runtime-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-runtime-config.yaml
@@ -26,6 +26,12 @@ overrides:
     {{- if $l.MaxGlobalStreamsPerTenant }}
     max_global_streams_per_user: {{ $l.MaxGlobalStreamsPerTenant }}
     {{- end }}
+    {{- if $l.PerStreamRateLimit }}
+    per_stream_rate_limit: {{ $l.PerStreamRateLimit }}MB
+    {{- end }}
+    {{- if $l.PerStreamRateLimitBurst }}
+    per_stream_rate_limit_burst: {{ $l.PerStreamRateLimitBurst }}MB
+    {{- end }}
   {{- end -}}
   {{- if $l := $spec.QueryLimits -}}
     {{- if $l.MaxEntriesLimitPerQuery }}

--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -171,12 +171,14 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 			Global: &lokiv1.LimitsTemplateSpec{
 				IngestionLimits: &lokiv1.IngestionLimitSpec{
 					// Defaults from Loki docs
-					IngestionRate:          4,
-					IngestionBurstSize:     6,
-					MaxLabelNameLength:     1024,
-					MaxLabelValueLength:    2048,
-					MaxLabelNamesPerSeries: 30,
-					MaxLineSize:            256000,
+					IngestionRate:           4,
+					IngestionBurstSize:      6,
+					MaxLabelNameLength:      1024,
+					MaxLabelValueLength:     2048,
+					MaxLabelNamesPerSeries:  30,
+					MaxLineSize:             256000,
+					PerStreamRateLimit:      3,
+					PerStreamRateLimitBurst: 15,
 				},
 				QueryLimits: &lokiv1.QueryLimitSpec{
 					// Defaults from Loki docs
@@ -227,10 +229,12 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 					IngestionBurstSize:        20,
 					MaxGlobalStreamsPerTenant: 10000,
 					// Defaults from Loki docs
-					MaxLabelNameLength:     1024,
-					MaxLabelValueLength:    2048,
-					MaxLabelNamesPerSeries: 30,
-					MaxLineSize:            256000,
+					MaxLabelNameLength:      1024,
+					MaxLabelValueLength:     2048,
+					MaxLabelNamesPerSeries:  30,
+					MaxLineSize:             256000,
+					PerStreamRateLimit:      3,
+					PerStreamRateLimitBurst: 15,
 				},
 				QueryLimits: &lokiv1.QueryLimitSpec{
 					// Defaults from Loki docs
@@ -281,10 +285,12 @@ var StackSizeTable = map[lokiv1.LokiStackSizeType]lokiv1.LokiStackSpec{
 					IngestionBurstSize:        20,
 					MaxGlobalStreamsPerTenant: 25000,
 					// Defaults from Loki docs
-					MaxLabelNameLength:     1024,
-					MaxLabelValueLength:    2048,
-					MaxLabelNamesPerSeries: 30,
-					MaxLineSize:            256000,
+					MaxLabelNameLength:      1024,
+					MaxLabelValueLength:     2048,
+					MaxLabelNamesPerSeries:  30,
+					MaxLineSize:             256000,
+					PerStreamRateLimit:      3,
+					PerStreamRateLimitBurst: 15,
 				},
 				QueryLimits: &lokiv1.QueryLimitSpec{
 					// Defaults from Loki docs


### PR DESCRIPTION
Description:

The present PR is a backport for `release-5.7` of the per_stream limit ingestion settings.

