### PR TITLE
[release-5.7] Fix openshift bundle manifest labels

### DIFF
--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-07-24T12:33:56Z"
+    createdAt: "2023-08-02T08:03:04Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2023-07-24T12:33:54Z"
+    createdAt: "2023-08-02T08:03:02Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
@@ -5,11 +5,11 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: loki-operator-metrics
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-controller-manager-metrics-service
 spec:
   ports:

--- a/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-manager-config_v1_configmap.yaml
@@ -62,9 +62,9 @@ data:
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-manager-config

--- a/operator/bundle/openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,11 +2,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
     name: loki-operator
   name: loki-operator-metrics-monitor
 spec:

--- a/operator/bundle/openshift/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -3,11 +3,11 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-metrics-reader
 rules:
 - nonResourceURLs:

--- a/operator/bundle/openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -6,11 +6,11 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-prometheus
 rules:
 - apiGroups:

--- a/operator/bundle/openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -6,11 +6,11 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/bundle/openshift/manifests/loki-operator-webhook-service_v1_service.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-webhook-service_v1_service.yaml
@@ -3,11 +3,11 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: loki-operator-webhook-service
 spec:
   ports:

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2023-07-24T12:33:58Z"
+    createdAt: "2023-08-02T08:03:06Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -1482,11 +1482,11 @@ spec:
         serviceAccountName: default
       deployments:
       - label:
-          app.kubernetes.io/instance: loki-operator-v0.0.1
+          app.kubernetes.io/instance: loki-operator-v0.1.0
           app.kubernetes.io/managed-by: operator-lifecycle-manager
           app.kubernetes.io/name: loki-operator
           app.kubernetes.io/part-of: cluster-logging
-          app.kubernetes.io/version: 0.0.1
+          app.kubernetes.io/version: 0.1.0
           control-plane: controller-manager
         name: loki-operator-controller-manager
         spec:

--- a/operator/bundle/openshift/manifests/loki.grafana.com_alertingrules.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_alertingrules.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: alertingrules.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_lokistacks.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: lokistacks.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/openshift/manifests/loki.grafana.com_recordingrules.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_recordingrules.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: recordingrules.loki.grafana.com
 spec:
   conversion:

--- a/operator/bundle/openshift/manifests/loki.grafana.com_rulerconfigs.yaml
+++ b/operator/bundle/openshift/manifests/loki.grafana.com_rulerconfigs.yaml
@@ -5,11 +5,11 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/instance: loki-operator-v0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: cluster-logging
-    app.kubernetes.io/version: 0.0.1
+    app.kubernetes.io/version: 0.1.0
   name: rulerconfigs.loki.grafana.com
 spec:
   conversion:

--- a/operator/config/overlays/openshift/kustomization.yaml
+++ b/operator/config/overlays/openshift/kustomization.yaml
@@ -22,8 +22,8 @@ labels:
     app.kubernetes.io/managed-by: operator-lifecycle-manager
   includeSelectors: true
 - pairs:
-    app.kubernetes.io/instance: loki-operator-v0.0.1
-    app.kubernetes.io/version: "0.0.1"
+    app.kubernetes.io/instance: loki-operator-v0.1.0
+    app.kubernetes.io/version: "0.1.0"
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -44,4 +44,4 @@ patchesStrategicMerge:
 images:
 - name: controller
   newName: quay.io/openshift-logging/loki-operator
-  newTag: v0.0.1
+  newTag: v0.1.0


### PR DESCRIPTION
Fix for downstream bundle builds to properly replace the labels in bundle manifests:
https://pkgs.devel.redhat.com/git/containers/loki-operator-bundle/tree/manifests/loki.grafana.com_alertingrules.yaml?h=openshift-logging-5.7-rhel-8#n7

as it used to be in 5.6 and previous builds:
https://pkgs.devel.redhat.com/git/containers/loki-operator-bundle/tree/manifests/loki.grafana.com_alertingrules.yaml?h=openshift-logging-5.6-rhel-8#n7

This issue arised from merging this upstream PR:
- grafana/loki/pull/7308