### PR TITLE
[release-5.6] Backport PR grafana/loki#10562

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.12
 
+- [10562](https://github.com/grafana/loki/pull/10562) **periklis**: Add memberlist IPv6 support
 - [10600](https://github.com/grafana/loki/pull/10600) **periklis**: Update Loki operand to v2.9.1
 
 ## Release 5.6.11

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -378,6 +378,16 @@ type MemberListSpec struct {
 	// +kubebuilder:validation:optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:select:default","urn:alm:descriptor:com.tectonic.ui:select:podIP"},displayName="Instance Address"
 	InstanceAddrType InstanceAddrType `json:"instanceAddrType,omitempty"`
+
+	// EnableIPv6 enables IPv6 support for the memberlist based hash ring.
+	//
+	// Currently this also forces the instanceAddrType to podIP to avoid local address lookup
+	// for the memberlist.
+	//
+	// +optional
+	// +kubebuilder:validation:Optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors="urn:alm:descriptor:com.tectonic.ui:booleanSwitch",displayName="Enable IPv6"
+	EnableIPv6 bool `json:"enableIPv6,omitempty"`
 }
 
 // HashRingSpec defines the hash ring configuration

--- a/operator/apis/loki/v1/lokistack_webhook.go
+++ b/operator/apis/loki/v1/lokistack_webhook.go
@@ -147,6 +147,10 @@ func (r *LokiStack) validate(old *LokiStack) error {
 		allErrs = append(allErrs, errors...)
 	}
 
+	errors = r.Spec.validateHashRingSpec()
+	if len(errors) != 0 {
+		allErrs = append(allErrs, errors...)
+	}
 	if len(allErrs) == 0 {
 		return nil
 	}
@@ -156,6 +160,28 @@ func (r *LokiStack) validate(old *LokiStack) error {
 		r.Name,
 		allErrs,
 	)
+}
+
+func (s *LokiStackSpec) validateHashRingSpec() field.ErrorList {
+	if s.HashRing == nil {
+		return nil
+	}
+
+	if s.HashRing.MemberList == nil {
+		return nil
+	}
+
+	if s.HashRing.MemberList.EnableIPv6 && s.HashRing.MemberList.InstanceAddrType == InstanceAddrDefault {
+		return field.ErrorList{
+			field.Invalid(
+				field.NewPath("spec", "hashRing", "memberlist", "instanceAddrType"),
+				s.HashRing.MemberList.InstanceAddrType,
+				ErrIPv6InstanceAddrTypeNotAllowed.Error(),
+			),
+		}
+	}
+
+	return nil
 }
 
 // buildAppliedSchemaMap creates a map of schemas which occur before the given time

--- a/operator/apis/loki/v1/lokistack_webhook_test.go
+++ b/operator/apis/loki/v1/lokistack_webhook_test.go
@@ -283,6 +283,39 @@ var ltt = []struct {
 			},
 		),
 	},
+	{
+		desc: "using default InstanceAddrType and enableIPv6",
+		spec: v1.LokiStack{
+			Spec: v1.LokiStackSpec{
+				HashRing: &v1.HashRingSpec{
+					Type: v1.HashRingMemberList,
+					MemberList: &v1.MemberListSpec{
+						EnableIPv6:       true,
+						InstanceAddrType: v1.InstanceAddrDefault,
+					},
+				},
+				Storage: v1.ObjectStorageSpec{
+					Schemas: []v1.ObjectStorageSchema{
+						{
+							Version:       v1.ObjectStorageSchemaV12,
+							EffectiveDate: "2020-10-11",
+						},
+					},
+				},
+			},
+		},
+		err: apierrors.NewInvalid(
+			schema.GroupKind{Group: "loki.grafana.com", Kind: "LokiStack"},
+			"testing-stack",
+			field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec", "hashRing", "memberlist", "instanceAddrType"),
+					v1.InstanceAddrDefault,
+					v1.ErrIPv6InstanceAddrTypeNotAllowed.Error(),
+				),
+			},
+		),
+	},
 }
 
 func TestLokiStackValidationWebhook_ValidateCreate(t *testing.T) {

--- a/operator/apis/loki/v1/v1.go
+++ b/operator/apis/loki/v1/v1.go
@@ -36,4 +36,6 @@ var (
 	ErrSchemaRetroactivelyRemoved = errors.New("Cannot retroactively remove schema(s)")
 	// ErrSchemaRetroactivelyChanged when a schema has been retroactively changed
 	ErrSchemaRetroactivelyChanged = errors.New("Cannot retroactively change schema")
+	// ErrIPv6InstanceAddrTypeNotAllowed when the default InstanceAddrType is used with enableIPv6.
+	ErrIPv6InstanceAddrTypeNotAllowed = errors.New(`instanceAddrType "default" cannot be used with enableIPv6 at the same time`)
 )

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -277,6 +277,13 @@ spec:
       - description: MemberList configuration spec
         displayName: Memberlist Config
         path: hashRing.memberlist
+      - description: "EnableIPv6 enables IPv6 support for the memberlist based hash
+          ring. \n Currently this also forces the instanceAddrType to podIP to avoid
+          local address lookup for the memberlist."
+        displayName: Enable IPv6
+        path: hashRing.memberlist.enableIPv6
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: InstanceAddrType defines the type of address to use to advertise
           to the ring. Defaults to the first address from any private network interfaces
           of the current pod. Alternatively the public pod IP can be used in case

--- a/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
+++ b/operator/bundle/manifests/loki.grafana.com_lokistacks.yaml
@@ -61,6 +61,11 @@ spec:
                   memberlist:
                     description: MemberList configuration spec
                     properties:
+                      enableIPv6:
+                        description: "EnableIPv6 enables IPv6 support for the memberlist
+                          based hash ring. \n Currently this also forces the instanceAddrType
+                          to podIP to avoid local address lookup for the memberlist."
+                        type: boolean
                       instanceAddrType:
                         description: InstanceAddrType defines the type of address
                           to use to advertise to the ring. Defaults to the first address

--- a/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
+++ b/operator/config/crd/bases/loki.grafana.com_lokistacks.yaml
@@ -44,6 +44,11 @@ spec:
                   memberlist:
                     description: MemberList configuration spec
                     properties:
+                      enableIPv6:
+                        description: "EnableIPv6 enables IPv6 support for the memberlist
+                          based hash ring. \n Currently this also forces the instanceAddrType
+                          to podIP to avoid local address lookup for the memberlist."
+                        type: boolean
                       instanceAddrType:
                         description: InstanceAddrType defines the type of address
                           to use to advertise to the ring. Defaults to the first address

--- a/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/loki-operator.clusterserviceversion.yaml
@@ -132,6 +132,13 @@ spec:
       - description: MemberList configuration spec
         displayName: Memberlist Config
         path: hashRing.memberlist
+      - description: "EnableIPv6 enables IPv6 support for the memberlist based hash
+          ring. \n Currently this also forces the instanceAddrType to podIP to avoid
+          local address lookup for the memberlist."
+        displayName: Enable IPv6
+        path: hashRing.memberlist.enableIPv6
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: InstanceAddrType defines the type of address to use to advertise
           to the ring. Defaults to the first address from any private network interfaces
           of the current pod. Alternatively the public pod IP can be used in case

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -1348,6 +1348,20 @@ Alternatively the public pod IP can be used in case private networks (RFC 1918 a
 are not available.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>enableIPv6</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableIPv6 enables IPv6 support for the memberlist based hash ring.</p>
+<p>Currently this also forces the instanceAddrType to podIP to avoid local address lookup
+for the memberlist.</p>
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -194,19 +194,31 @@ func alertManagerConfig(s *lokiv1beta1.AlertManagerSpec) *config.AlertManagerCon
 }
 
 func gossipRingConfig(stackName, stackNs string, spec *lokiv1.HashRingSpec) config.GossipRing {
-	var instanceAddr string
+	var (
+		instanceAddr string
+		enableIPv6   bool
+	)
 	if spec != nil && spec.Type == lokiv1.HashRingMemberList && spec.MemberList != nil {
 		switch spec.MemberList.InstanceAddrType {
 		case lokiv1.InstanceAddrPodIP:
-			instanceAddr = fmt.Sprintf("${%s}", gossipInstanceAddrEnvVarName)
+			instanceAddr = gossipInstanceAddrEnvVarTemplate
 		case lokiv1.InstanceAddrDefault:
 			// Do nothing use loki defaults
 		default:
 			// Do nothing use loki defaults
 		}
+
+		// Always default to use the pod IP address when IPv6 enabled to ensure:
+		// - On Single Stack IPv6: Skip interface checking
+		// - On Dual Stack IPv4/6: Eliminate duplicate memberlist node registration
+		if spec.MemberList.EnableIPv6 {
+			enableIPv6 = true
+			instanceAddr = gossipInstanceAddrEnvVarTemplate
+		}
 	}
 
 	return config.GossipRing{
+		EnableIPv6:           enableIPv6,
 		InstanceAddr:         instanceAddr,
 		InstancePort:         grpcPort,
 		BindPort:             gossipPort,

--- a/operator/internal/manifests/config_test.go
+++ b/operator/internal/manifests/config_test.go
@@ -259,6 +259,43 @@ func TestConfigOptions_GossipRingConfig(t *testing.T) {
 				MembersDiscoveryAddr: "my-stack-gossip-ring.my-ns.svc.cluster.local",
 			},
 		},
+		{
+			desc: "IPv6 enabled with default instance address type",
+			spec: lokiv1.LokiStackSpec{
+				HashRing: &lokiv1.HashRingSpec{
+					Type: lokiv1.HashRingMemberList,
+					MemberList: &lokiv1.MemberListSpec{
+						EnableIPv6: true,
+					},
+				},
+			},
+			wantOptions: config.GossipRing{
+				EnableIPv6:           true,
+				InstanceAddr:         "${HASH_RING_INSTANCE_ADDR}",
+				InstancePort:         9095,
+				BindPort:             7946,
+				MembersDiscoveryAddr: "my-stack-gossip-ring.my-ns.svc.cluster.local",
+			},
+		},
+		{
+			desc: "IPv6 enabled with podIP instance address type",
+			spec: lokiv1.LokiStackSpec{
+				HashRing: &lokiv1.HashRingSpec{
+					Type: lokiv1.HashRingMemberList,
+					MemberList: &lokiv1.MemberListSpec{
+						EnableIPv6:       true,
+						InstanceAddrType: lokiv1.InstanceAddrPodIP,
+					},
+				},
+			},
+			wantOptions: config.GossipRing{
+				EnableIPv6:           true,
+				InstanceAddr:         "${HASH_RING_INSTANCE_ADDR}",
+				InstancePort:         9095,
+				BindPort:             7946,
+				MembersDiscoveryAddr: "my-stack-gossip-ring.my-ns.svc.cluster.local",
+			},
+		},
 	}
 	for _, tc := range tt {
 		tc := tc

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -3003,3 +3003,259 @@ overrides:
 	require.YAMLEq(t, expCfg, string(cfg))
 	require.YAMLEq(t, expRCfg, string(rCfg))
 }
+
+func TestBuild_ConfigAndRuntimeConfig_WithHashRingSpec_EnableIPv6(t *testing.T) {
+	expCfg := `
+---
+auth_enabled: true
+chunk_store_config:
+  chunk_cache_config:
+    embedded_cache:
+      enabled: true
+      max_size_mb: 500
+common:
+  storage:
+    s3:
+      s3: http://test.default.svc.cluster.local.:9000
+      bucketnames: loki
+      region: us-east
+      access_key_id: test
+      secret_access_key: test123
+      s3forcepathstyle: true
+  compactor_grpc_address: loki-compactor-grpc-lokistack-dev.default.svc.cluster.local:9095
+  ring:
+    kvstore:
+      store: memberlist
+    heartbeat_period: 5s
+    heartbeat_timeout: 1m
+    instance_addr: ${HASH_RING_INSTANCE_ADDR}
+    instance_port: 9095
+compactor:
+  compaction_interval: 2h
+  working_directory: /tmp/loki/compactor
+frontend:
+  tail_proxy_url: http://loki-querier-http-lokistack-dev.default.svc.cluster.local:3100
+  compress_responses: true
+  max_outstanding_per_tenant: 256
+  log_queries_longer_than: 5s
+frontend_worker:
+  frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
+  grpc_client_config:
+    max_send_msg_size: 104857600
+  match_max_concurrent: true
+ingester:
+  chunk_block_size: 262144
+  chunk_encoding: snappy
+  chunk_idle_period: 1h
+  chunk_retain_period: 5m
+  chunk_target_size: 2097152
+  flush_op_timeout: 10m
+  lifecycler:
+    final_sleep: 0s
+    join_after: 30s
+    num_tokens: 512
+    enable_inet6: true
+    ring:
+      replication_factor: 1
+  max_chunk_age: 2h
+  max_transfer_retries: 0
+  wal:
+    enabled: true
+    dir: /tmp/wal
+    replay_memory_ceiling: 2500
+ingester_client:
+  grpc_client_config:
+    max_recv_msg_size: 67108864
+  remote_timeout: 1s
+# NOTE: Keep the order of keys as in Loki docs
+# to enable easy diffs when vendoring newer
+# Loki releases.
+# (See https://grafana.com/docs/loki/latest/configuration/#limits_config)
+#
+# Values for not exposed fields are taken from the grafana/loki production
+# configuration manifests.
+# (See https://github.com/grafana/loki/blob/main/production/ksonnet/loki/config.libsonnet)
+limits_config:
+  ingestion_rate_strategy: global
+  ingestion_rate_mb: 4
+  ingestion_burst_size_mb: 6
+  max_label_name_length: 1024
+  max_label_value_length: 2048
+  max_label_names_per_series: 30
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  creation_grace_period: 10m
+  enforce_metric_name: false
+  # Keep max_streams_per_user always to 0 to default
+  # using max_global_streams_per_user always.
+  # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
+  max_streams_per_user: 0
+  max_line_size: 256000
+  max_entries_limit_per_query: 5000
+  max_global_streams_per_user: 0
+  max_chunks_per_query: 2000000
+  max_query_length: 721h
+  max_query_parallelism: 32
+  max_query_series: 500
+  cardinality_limit: 100000
+  max_streams_matchers_per_query: 1000
+  max_cache_freshness_per_query: 10m
+  per_stream_rate_limit: 3MB
+  per_stream_rate_limit_burst: 15MB
+  split_queries_by_interval: 30m
+  query_timeout: 1m
+memberlist:
+  abort_if_cluster_join_fails: true
+  advertise_addr: ${HASH_RING_INSTANCE_ADDR}
+  advertise_port: 7946
+  bind_port: 7946
+  join_members:
+    - loki-gossip-ring-lokistack-dev.default.svc.cluster.local:7946
+  max_join_backoff: 1m
+  max_join_retries: 10
+  min_join_backoff: 1s
+querier:
+  engine:
+    max_look_back_period: 30s
+    timeout: 3m
+  extra_query_delay: 0s
+  max_concurrent: 2
+  query_ingesters_within: 3h
+  tail_max_duration: 1h
+query_range:
+  align_queries_with_step: true
+  cache_results: true
+  max_retries: 5
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 500
+  parallelise_shardable_queries: true
+schema_config:
+  configs:
+    - from: "2020-10-01"
+      index:
+        period: 24h
+        prefix: index_
+      object_store: s3
+      schema: v11
+      store: boltdb-shipper
+server:
+  graceful_shutdown_timeout: 5s
+  grpc_server_min_time_between_pings: '10s'
+  grpc_server_ping_without_stream_allowed: true
+  grpc_server_max_concurrent_streams: 1000
+  grpc_server_max_recv_msg_size: 104857600
+  grpc_server_max_send_msg_size: 104857600
+  http_listen_port: 3100
+  http_server_idle_timeout: 30s
+  http_server_read_timeout: 30s
+  http_server_write_timeout: 10m0s
+  log_level: info
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+    cache_ttl: 24h
+    resync_interval: 5m
+    shared_store: s3
+    index_gateway_client:
+      server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
+tracing:
+  enabled: false
+analytics:
+  reporting_enabled: true
+`
+	expRCfg := `
+---
+overrides:
+`
+	opts := Options{
+		Stack: lokiv1.LokiStackSpec{
+			ReplicationFactor: 1,
+			Limits: &lokiv1.LimitsSpec{
+				Global: &lokiv1.LimitsTemplateSpec{
+					IngestionLimits: &lokiv1.IngestionLimitSpec{
+						IngestionRate:             4,
+						IngestionBurstSize:        6,
+						MaxLabelNameLength:        1024,
+						MaxLabelValueLength:       2048,
+						MaxLabelNamesPerSeries:    30,
+						MaxGlobalStreamsPerTenant: 0,
+						MaxLineSize:               256000,
+						PerStreamRateLimit:        3,
+						PerStreamRateLimitBurst:   15,
+					},
+					QueryLimits: &lokiv1.QueryLimitSpec{
+						MaxEntriesLimitPerQuery: 5000,
+						MaxChunksPerQuery:       2000000,
+						MaxQuerySeries:          500,
+						QueryTimeout:            "1m",
+						CardinalityLimit:        100000,
+					},
+				},
+			},
+		},
+		Namespace: "test-ns",
+		Name:      "test",
+		Compactor: Address{
+			FQDN: "loki-compactor-grpc-lokistack-dev.default.svc.cluster.local",
+			Port: 9095,
+		},
+		FrontendWorker: Address{
+			FQDN: "loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local",
+			Port: 9095,
+		},
+		GossipRing: GossipRing{
+			EnableIPv6:           true,
+			InstanceAddr:         "${HASH_RING_INSTANCE_ADDR}",
+			InstancePort:         9095,
+			BindPort:             7946,
+			MembersDiscoveryAddr: "loki-gossip-ring-lokistack-dev.default.svc.cluster.local",
+		},
+		Querier: Address{
+			Protocol: "http",
+			FQDN:     "loki-querier-http-lokistack-dev.default.svc.cluster.local",
+			Port:     3100,
+		},
+		IndexGateway: Address{
+			FQDN: "loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local",
+			Port: 9095,
+		},
+		StorageDirectory: "/tmp/loki",
+		MaxConcurrent: MaxConcurrent{
+			AvailableQuerierCPUCores: 2,
+		},
+		WriteAheadLog: WriteAheadLog{
+			Directory:             "/tmp/wal",
+			IngesterMemoryRequest: 5000,
+		},
+		ObjectStorage: storage.Options{
+			SharedStore: lokiv1.ObjectStorageSecretS3,
+			S3: &storage.S3StorageConfig{
+				Endpoint:        "http://test.default.svc.cluster.local.:9000",
+				Region:          "us-east",
+				Buckets:         "loki",
+				AccessKeyID:     "test",
+				AccessKeySecret: "test123",
+			},
+			Schemas: []lokiv1.ObjectStorageSchema{
+				{
+					Version:       lokiv1.ObjectStorageSchemaV11,
+					EffectiveDate: "2020-10-01",
+				},
+			},
+		},
+		EnableRemoteReporting: true,
+		HTTPTimeouts: HTTPTimeoutConfig{
+			IdleTimeout:  30 * time.Second,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 10 * time.Minute,
+		},
+	}
+	cfg, rCfg, err := Build(opts)
+	require.NoError(t, err)
+	require.YAMLEq(t, expCfg, string(cfg))
+	require.YAMLEq(t, expRCfg, string(rCfg))
+}

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -105,6 +105,9 @@ ingester:
     final_sleep: 0s
     join_after: 30s
     num_tokens: 512
+    {{- if .GossipRing.EnableIPv6 }}
+    enable_inet6: true
+    {{- end}}
     ring:
       replication_factor: {{ .Stack.ReplicationFactor }}
   max_transfer_retries: 0

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -49,6 +49,8 @@ type Address struct {
 
 // GossipRing defines the memberlist configuration
 type GossipRing struct {
+	// EnableIPv6 is optional, memberlist IPv6 support
+	EnableIPv6 bool
 	// InstanceAddr is optional, defaults to private networks
 	InstanceAddr string
 	// InstancePort is required

--- a/operator/internal/manifests/memberlist.go
+++ b/operator/internal/manifests/memberlist.go
@@ -54,11 +54,9 @@ func configureHashRingEnv(p *corev1.PodSpec, opts Options) error {
 		return nil
 	}
 
-	switch hashRing.MemberList.InstanceAddrType {
-	case "", lokiv1.InstanceAddrDefault:
+	memberList := hashRing.MemberList
+	if !memberList.EnableIPv6 && memberList.InstanceAddrType != lokiv1.InstanceAddrPodIP {
 		return nil
-	default:
-		// Proceed with appending env var
 	}
 
 	src := corev1.Container{

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -20,7 +20,8 @@ const (
 	grpcPort         = 9095
 	protocolTCP      = "TCP"
 
-	gossipInstanceAddrEnvVarName = "HASH_RING_INSTANCE_ADDR"
+	gossipInstanceAddrEnvVarName     = "HASH_RING_INSTANCE_ADDR"
+	gossipInstanceAddrEnvVarTemplate = "${" + gossipInstanceAddrEnvVarName + "}"
 
 	lokiHTTPPortName         = "metrics"
 	lokiInternalHTTPPortName = "healthchecks"


### PR DESCRIPTION
Bakports the memberlist IPv6 support to `release-5.6`

Ref: [LOG-4570](https://issues.redhat.com//browse/LOG-4570) 

/cc @xperimental