### PR TITLE
[release-5.6] Backport PR grafana/loki#11288

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Main
 
+## Release 5.6.14
+
+- [11288](https://github.com/grafana/loki/pull/11288) **periklis**: Fix custom CA for object-store in ruler component
+
+## Release 5.6.13
+
+No changes.
+
 ## Release 5.6.12
 
 - [10924](https://github.com/grafana/loki/pull/10924) **periklis**: Update Loki operand to v2.9.2

--- a/operator/internal/manifests/ruler.go
+++ b/operator/internal/manifests/ruler.go
@@ -7,6 +7,7 @@ import (
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
 	"github.com/grafana/loki/operator/internal/manifests/internal/config"
 	"github.com/grafana/loki/operator/internal/manifests/openshift"
+	"github.com/grafana/loki/operator/internal/manifests/storage"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +26,10 @@ func BuildRuler(opts Options) ([]client.Object, error) {
 		if err := configureRulerHTTPServicePKI(statefulSet, opts); err != nil {
 			return nil, err
 		}
+	}
+
+	if err := storage.ConfigureStatefulSet(statefulSet, opts.ObjectStorage); err != nil {
+		return nil, err
 	}
 
 	if opts.Gates.GRPCEncryption {


### PR DESCRIPTION
Backport ruler CA fixes for `release-5.6`

Refs: [LOG-4838](https://issues.redhat.com//browse/LOG-4838)