### PR TITLE
LOG-5058: Improve messages for errors in storage secret

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Main
 
+## Release 5.8.4
+
+- [11824](https://github.com/grafana/loki/pull/11824) **xperimental**: Improve messages for errors in storage secret
+
 ## Release 5.8.3
 
 - [11232](https://github.com/grafana/loki/pull/11232) **periklis**: Update dependencies and dev tools

--- a/operator/internal/handlers/internal/storage/storage_test.go
+++ b/operator/internal/handlers/internal/storage/storage_test.go
@@ -134,7 +134,7 @@ func TestBuildOptions_WhenInvalidSecret_SetDegraded(t *testing.T) {
 	}
 
 	degradedErr := &status.DegradedError{
-		Message: "Invalid object storage secret contents: missing secret field",
+		Message: "Invalid object storage secret contents: missing secret field: bucketnames",
 		Reason:  lokiv1.ReasonInvalidObjectStorageSecret,
 		Requeue: false,
 	}


### PR DESCRIPTION
This is a backport of grafana/loki#11824 to 5.8. Implements [LOG-5058](https://issues.redhat.com//browse/LOG-5058).
