### PR TITLE
LOG-5172: Extend status to show difference between running and ready

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.7.12
 
+- [11968](https://github.com/grafana/loki/pull/11968) **xperimental**: Extend status to show difference between running and ready
 - [11824](https://github.com/grafana/loki/pull/11824) **xperimental**: Improve messages for errors in storage secret
 
 ## Release 5.7.11

--- a/operator/apis/loki/v1/lokistack_types.go
+++ b/operator/apis/loki/v1/lokistack_types.go
@@ -889,8 +889,28 @@ const (
 	ReasonQueryTimeoutInvalid LokiStackConditionReason = "ReasonQueryTimeoutInvalid"
 )
 
+// PodStatus is a short description of the status a Pod can be in.
+type PodStatus string
+
+const (
+	// PodPending means the pod has been accepted by the system, but one or more of the containers
+	// has not been started. This includes time before being bound to a node, as well as time spent
+	// pulling images onto the host.
+	PodPending PodStatus = "Pending"
+	// PodRunning means the pod has been bound to a node and all of the containers have been started.
+	// At least one container is still running or is in the process of being restarted.
+	PodRunning PodStatus = "Running"
+	// PodReady means the pod has been started and the readiness probe reports a successful status.
+	PodReady PodStatus = "Ready"
+	// PodFailed means that all containers in the pod have terminated, and at least one container has
+	// terminated in a failure (exited with a non-zero exit code or was stopped by the system).
+	PodFailed PodStatus = "Failed"
+	// PodStatusUnknown is used when none of the other statuses apply or the information is not ready yet.
+	PodStatusUnknown PodStatus = "Unknown"
+)
+
 // PodStatusMap defines the type for mapping pod status to pod name.
-type PodStatusMap map[corev1.PodPhase][]string
+type PodStatusMap map[PodStatus][]string
 
 // LokiStackComponentStatus defines the map of per pod status per LokiStack component.
 // Each component is represented by a separate map of v1.Phase to a list of pods.

--- a/operator/apis/loki/v1beta1/lokistack_types.go
+++ b/operator/apis/loki/v1beta1/lokistack_types.go
@@ -829,6 +829,30 @@ func init() {
 	SchemeBuilder.Register(&LokiStack{}, &LokiStackList{})
 }
 
+func convertStatusV1(src PodStatusMap) v1.PodStatusMap {
+	if src == nil {
+		return nil
+	}
+
+	dst := v1.PodStatusMap{}
+	for k, v := range src {
+		dst[v1.PodStatus(k)] = v
+	}
+	return dst
+}
+
+func convertStatusBeta(src v1.PodStatusMap) PodStatusMap {
+	if src == nil {
+		return nil
+	}
+
+	dst := PodStatusMap{}
+	for k, v := range src {
+		dst[corev1.PodPhase(k)] = v
+	}
+	return dst
+}
+
 // ConvertTo converts this LokiStack (v1beta1) to the Hub version (v1).
 func (src *LokiStack) ConvertTo(dstRaw conversion.Hub) error {
 	dst := dstRaw.(*v1.LokiStack)
@@ -836,14 +860,14 @@ func (src *LokiStack) ConvertTo(dstRaw conversion.Hub) error {
 	dst.ObjectMeta = src.ObjectMeta
 	dst.Status.Conditions = src.Status.Conditions
 	dst.Status.Components = v1.LokiStackComponentStatus{
-		Compactor:     v1.PodStatusMap(src.Status.Components.Compactor),
-		Distributor:   v1.PodStatusMap(src.Status.Components.Distributor),
-		Ingester:      v1.PodStatusMap(src.Status.Components.Ingester),
-		Querier:       v1.PodStatusMap(src.Status.Components.Querier),
-		QueryFrontend: v1.PodStatusMap(src.Status.Components.QueryFrontend),
-		IndexGateway:  v1.PodStatusMap(src.Status.Components.IndexGateway),
-		Ruler:         v1.PodStatusMap(src.Status.Components.Ruler),
-		Gateway:       v1.PodStatusMap(src.Status.Components.Gateway),
+		Compactor:     convertStatusV1(src.Status.Components.Compactor),
+		Distributor:   convertStatusV1(src.Status.Components.Distributor),
+		Ingester:      convertStatusV1(src.Status.Components.Ingester),
+		Querier:       convertStatusV1(src.Status.Components.Querier),
+		QueryFrontend: convertStatusV1(src.Status.Components.QueryFrontend),
+		IndexGateway:  convertStatusV1(src.Status.Components.IndexGateway),
+		Ruler:         convertStatusV1(src.Status.Components.Ruler),
+		Gateway:       convertStatusV1(src.Status.Components.Gateway),
 	}
 
 	var statusSchemas []v1.ObjectStorageSchema
@@ -1102,14 +1126,14 @@ func (dst *LokiStack) ConvertFrom(srcRaw conversion.Hub) error {
 	dst.ObjectMeta = src.ObjectMeta
 	dst.Status.Conditions = src.Status.Conditions
 	dst.Status.Components = LokiStackComponentStatus{
-		Compactor:     PodStatusMap(src.Status.Components.Compactor),
-		Distributor:   PodStatusMap(src.Status.Components.Distributor),
-		Ingester:      PodStatusMap(src.Status.Components.Ingester),
-		Querier:       PodStatusMap(src.Status.Components.Querier),
-		QueryFrontend: PodStatusMap(src.Status.Components.QueryFrontend),
-		IndexGateway:  PodStatusMap(src.Status.Components.IndexGateway),
-		Ruler:         PodStatusMap(src.Status.Components.Ruler),
-		Gateway:       PodStatusMap(src.Status.Components.Gateway),
+		Compactor:     convertStatusBeta(src.Status.Components.Compactor),
+		Distributor:   convertStatusBeta(src.Status.Components.Distributor),
+		Ingester:      convertStatusBeta(src.Status.Components.Ingester),
+		Querier:       convertStatusBeta(src.Status.Components.Querier),
+		QueryFrontend: convertStatusBeta(src.Status.Components.QueryFrontend),
+		IndexGateway:  convertStatusBeta(src.Status.Components.IndexGateway),
+		Ruler:         convertStatusBeta(src.Status.Components.Ruler),
+		Gateway:       convertStatusBeta(src.Status.Components.Gateway),
 	}
 
 	var statusSchemas []ObjectStorageSchema

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2024-01-26T13:24:01Z"
+    createdAt: "2024-03-04T17:34:37Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2024-01-26T13:23:59Z"
+    createdAt: "2024-03-04T17:34:34Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2024-01-26T13:24:04Z"
+    createdAt: "2024-03-04T17:34:40Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/docs/operator/api.md
+++ b/operator/docs/operator/api.md
@@ -2533,8 +2533,42 @@ It needs to be in the same namespace as the LokiStack custom resource.</p>
 </tr></tbody>
 </table>
 
+## PodStatus { #loki-grafana-com-v1-PodStatus }
+(<code>string</code> alias)
+<div>
+<p>PodStatus is a short description of the status a Pod can be in.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;Failed&#34;</p></td>
+<td><p>PodFailed means that all containers in the pod have terminated, and at least one container has
+terminated in a failure (exited with a non-zero exit code or was stopped by the system).</p>
+</td>
+</tr><tr><td><p>&#34;Pending&#34;</p></td>
+<td><p>PodPending means the pod has been accepted by the system, but one or more of the containers
+has not been started. This includes time before being bound to a node, as well as time spent
+pulling images onto the host.</p>
+</td>
+</tr><tr><td><p>&#34;Ready&#34;</p></td>
+<td><p>PodReady means the pod has been started and the readiness probe reports a successful status.</p>
+</td>
+</tr><tr><td><p>&#34;Running&#34;</p></td>
+<td><p>PodRunning means the pod has been bound to a node and all of the containers have been started.
+At least one container is still running or is in the process of being restarted.</p>
+</td>
+</tr><tr><td><p>&#34;Unknown&#34;</p></td>
+<td><p>PodStatusUnknown is used when none of the other statuses apply or the information is not ready yet.</p>
+</td>
+</tr></tbody>
+</table>
+
 ## PodStatusMap { #loki-grafana-com-v1-PodStatusMap }
-(<code>map[k8s.io/api/core/v1.PodPhase][]string</code> alias)
+(<code>map[github.com/grafana/loki/operator/apis/loki/v1.PodStatus][]string</code> alias)
 <p>
 (<em>Appears on:</em><a href="#loki-grafana-com-v1-LokiStackComponentStatus">LokiStackComponentStatus</a>)
 </p>

--- a/operator/internal/status/components_test.go
+++ b/operator/internal/status/components_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/grafana/loki/operator/internal/manifests"
 )
 
-func createPodList(baseName string, phases ...corev1.PodPhase) *corev1.PodList {
+func createPodList(baseName string, ready bool, phases ...corev1.PodPhase) *corev1.PodList {
 	items := []corev1.Pod{}
 	for i, p := range phases {
 		items = append(items, corev1.Pod{
@@ -24,6 +24,11 @@ func createPodList(baseName string, phases ...corev1.PodPhase) *corev1.PodList {
 			},
 			Status: corev1.PodStatus{
 				Phase: p,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Ready: ready,
+					},
+				},
 			},
 		})
 	}
@@ -78,37 +83,37 @@ func TestGenerateComponentStatus(t *testing.T) {
 				manifests.LabelGatewayComponent:       {},
 			},
 			wantComponentStatus: &lokiv1.LokiStackComponentStatus{
-				Compactor:     map[corev1.PodPhase][]string{},
-				Distributor:   map[corev1.PodPhase][]string{},
-				IndexGateway:  map[corev1.PodPhase][]string{},
-				Ingester:      map[corev1.PodPhase][]string{},
-				Querier:       map[corev1.PodPhase][]string{},
-				QueryFrontend: map[corev1.PodPhase][]string{},
-				Gateway:       map[corev1.PodPhase][]string{},
-				Ruler:         map[corev1.PodPhase][]string{},
+				Compactor:     lokiv1.PodStatusMap{},
+				Distributor:   lokiv1.PodStatusMap{},
+				IndexGateway:  lokiv1.PodStatusMap{},
+				Ingester:      lokiv1.PodStatusMap{},
+				Querier:       lokiv1.PodStatusMap{},
+				QueryFrontend: lokiv1.PodStatusMap{},
+				Gateway:       lokiv1.PodStatusMap{},
+				Ruler:         lokiv1.PodStatusMap{},
 			},
 		},
 		{
 			desc: "all one pod running",
 			componentPods: map[string]*corev1.PodList{
-				manifests.LabelCompactorComponent:     createPodList(manifests.LabelCompactorComponent, corev1.PodRunning),
-				manifests.LabelDistributorComponent:   createPodList(manifests.LabelDistributorComponent, corev1.PodRunning),
-				manifests.LabelIngesterComponent:      createPodList(manifests.LabelIngesterComponent, corev1.PodRunning),
-				manifests.LabelQuerierComponent:       createPodList(manifests.LabelQuerierComponent, corev1.PodRunning),
-				manifests.LabelQueryFrontendComponent: createPodList(manifests.LabelQueryFrontendComponent, corev1.PodRunning),
-				manifests.LabelIndexGatewayComponent:  createPodList(manifests.LabelIndexGatewayComponent, corev1.PodRunning),
-				manifests.LabelRulerComponent:         createPodList(manifests.LabelRulerComponent, corev1.PodRunning),
-				manifests.LabelGatewayComponent:       createPodList(manifests.LabelGatewayComponent, corev1.PodRunning),
+				manifests.LabelCompactorComponent:     createPodList(manifests.LabelCompactorComponent, false, corev1.PodRunning),
+				manifests.LabelDistributorComponent:   createPodList(manifests.LabelDistributorComponent, false, corev1.PodRunning),
+				manifests.LabelIngesterComponent:      createPodList(manifests.LabelIngesterComponent, false, corev1.PodRunning),
+				manifests.LabelQuerierComponent:       createPodList(manifests.LabelQuerierComponent, false, corev1.PodRunning),
+				manifests.LabelQueryFrontendComponent: createPodList(manifests.LabelQueryFrontendComponent, false, corev1.PodRunning),
+				manifests.LabelIndexGatewayComponent:  createPodList(manifests.LabelIndexGatewayComponent, false, corev1.PodRunning),
+				manifests.LabelRulerComponent:         createPodList(manifests.LabelRulerComponent, false, corev1.PodRunning),
+				manifests.LabelGatewayComponent:       createPodList(manifests.LabelGatewayComponent, false, corev1.PodRunning),
 			},
 			wantComponentStatus: &lokiv1.LokiStackComponentStatus{
-				Compactor:     map[corev1.PodPhase][]string{corev1.PodRunning: {"compactor-pod-0"}},
-				Distributor:   map[corev1.PodPhase][]string{corev1.PodRunning: {"distributor-pod-0"}},
-				IndexGateway:  map[corev1.PodPhase][]string{corev1.PodRunning: {"index-gateway-pod-0"}},
-				Ingester:      map[corev1.PodPhase][]string{corev1.PodRunning: {"ingester-pod-0"}},
-				Querier:       map[corev1.PodPhase][]string{corev1.PodRunning: {"querier-pod-0"}},
-				QueryFrontend: map[corev1.PodPhase][]string{corev1.PodRunning: {"query-frontend-pod-0"}},
-				Gateway:       map[corev1.PodPhase][]string{corev1.PodRunning: {"lokistack-gateway-pod-0"}},
-				Ruler:         map[corev1.PodPhase][]string{corev1.PodRunning: {"ruler-pod-0"}},
+				Compactor:     lokiv1.PodStatusMap{lokiv1.PodRunning: {"compactor-pod-0"}},
+				Distributor:   lokiv1.PodStatusMap{lokiv1.PodRunning: {"distributor-pod-0"}},
+				IndexGateway:  lokiv1.PodStatusMap{lokiv1.PodRunning: {"index-gateway-pod-0"}},
+				Ingester:      lokiv1.PodStatusMap{lokiv1.PodRunning: {"ingester-pod-0"}},
+				Querier:       lokiv1.PodStatusMap{lokiv1.PodRunning: {"querier-pod-0"}},
+				QueryFrontend: lokiv1.PodStatusMap{lokiv1.PodRunning: {"query-frontend-pod-0"}},
+				Gateway:       lokiv1.PodStatusMap{lokiv1.PodRunning: {"lokistack-gateway-pod-0"}},
+				Ruler:         lokiv1.PodStatusMap{lokiv1.PodRunning: {"ruler-pod-0"}},
 			},
 		},
 	}

--- a/operator/internal/status/lokistack.go
+++ b/operator/internal/status/lokistack.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/ViaQ/logerr/v2/kverrors"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
@@ -17,8 +16,9 @@ import (
 
 const (
 	messageReady   = "All components ready"
-	messageFailed  = "Some LokiStack components failed"
-	messagePending = "Some LokiStack components pending on dependencies"
+	messageFailed  = "One or more LokiStack components failed"
+	messagePending = "One or more LokiStack components pending on dependencies"
+	messageRunning = "All components are running, but some readiness checks are failing"
 )
 
 var (
@@ -30,6 +30,11 @@ var (
 	conditionPending = metav1.Condition{
 		Type:    string(lokiv1.ConditionPending),
 		Message: messagePending,
+		Reason:  string(lokiv1.ReasonPendingComponents),
+	}
+	conditionRunning = metav1.Condition{
+		Type:    string(lokiv1.ConditionPending),
+		Message: messageRunning,
 		Reason:  string(lokiv1.ReasonPendingComponents),
 	}
 	conditionReady = metav1.Condition{
@@ -63,31 +68,45 @@ func SetDegradedCondition(ctx context.Context, k k8s.Client, req ctrl.Request, m
 
 func generateCondition(cs *lokiv1.LokiStackComponentStatus) metav1.Condition {
 	// Check for failed pods first
-	failed := len(cs.Compactor[corev1.PodFailed]) +
-		len(cs.Distributor[corev1.PodFailed]) +
-		len(cs.Ingester[corev1.PodFailed]) +
-		len(cs.Querier[corev1.PodFailed]) +
-		len(cs.QueryFrontend[corev1.PodFailed]) +
-		len(cs.Gateway[corev1.PodFailed]) +
-		len(cs.IndexGateway[corev1.PodFailed]) +
-		len(cs.Ruler[corev1.PodFailed])
+	failed := len(cs.Compactor[lokiv1.PodFailed]) +
+		len(cs.Distributor[lokiv1.PodFailed]) +
+		len(cs.Ingester[lokiv1.PodFailed]) +
+		len(cs.Querier[lokiv1.PodFailed]) +
+		len(cs.QueryFrontend[lokiv1.PodFailed]) +
+		len(cs.Gateway[lokiv1.PodFailed]) +
+		len(cs.IndexGateway[lokiv1.PodFailed]) +
+		len(cs.Ruler[lokiv1.PodFailed])
 
 	if failed != 0 {
 		return conditionFailed
 	}
 
 	// Check for pending pods
-	pending := len(cs.Compactor[corev1.PodPending]) +
-		len(cs.Distributor[corev1.PodPending]) +
-		len(cs.Ingester[corev1.PodPending]) +
-		len(cs.Querier[corev1.PodPending]) +
-		len(cs.QueryFrontend[corev1.PodPending]) +
-		len(cs.Gateway[corev1.PodPending]) +
-		len(cs.IndexGateway[corev1.PodPending]) +
-		len(cs.Ruler[corev1.PodPending])
+	pending := len(cs.Compactor[lokiv1.PodPending]) +
+		len(cs.Distributor[lokiv1.PodPending]) +
+		len(cs.Ingester[lokiv1.PodPending]) +
+		len(cs.Querier[lokiv1.PodPending]) +
+		len(cs.QueryFrontend[lokiv1.PodPending]) +
+		len(cs.Gateway[lokiv1.PodPending]) +
+		len(cs.IndexGateway[lokiv1.PodPending]) +
+		len(cs.Ruler[lokiv1.PodPending])
 
 	if pending != 0 {
 		return conditionPending
+	}
+
+	// Check if there are pods that are running but not ready
+	running := len(cs.Compactor[lokiv1.PodRunning]) +
+		len(cs.Distributor[lokiv1.PodRunning]) +
+		len(cs.Ingester[lokiv1.PodRunning]) +
+		len(cs.Querier[lokiv1.PodRunning]) +
+		len(cs.QueryFrontend[lokiv1.PodRunning]) +
+		len(cs.Gateway[lokiv1.PodRunning]) +
+		len(cs.IndexGateway[lokiv1.PodRunning]) +
+		len(cs.Ruler[lokiv1.PodRunning])
+
+	if running > 0 {
+		return conditionRunning
 	}
 
 	return conditionReady

--- a/operator/internal/status/lokistack_test.go
+++ b/operator/internal/status/lokistack_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -167,8 +166,8 @@ func TestGenerateConditions(t *testing.T) {
 		{
 			desc: "container pending",
 			componentStatus: &lokiv1.LokiStackComponentStatus{
-				Ingester: map[corev1.PodPhase][]string{
-					corev1.PodPending: {
+				Ingester: lokiv1.PodStatusMap{
+					lokiv1.PodPending: {
 						"pod-0",
 					},
 				},
@@ -178,8 +177,8 @@ func TestGenerateConditions(t *testing.T) {
 		{
 			desc: "container failed",
 			componentStatus: &lokiv1.LokiStackComponentStatus{
-				Ingester: map[corev1.PodPhase][]string{
-					corev1.PodFailed: {
+				Ingester: lokiv1.PodStatusMap{
+					lokiv1.PodFailed: {
 						"pod-0",
 					},
 				},

--- a/operator/internal/status/status_test.go
+++ b/operator/internal/status/status_test.go
@@ -32,26 +32,26 @@ func TestRefreshSuccess(t *testing.T) {
 	}
 
 	componentPods := map[string]*corev1.PodList{
-		manifests.LabelCompactorComponent:     createPodList(manifests.LabelCompactorComponent, corev1.PodRunning),
-		manifests.LabelDistributorComponent:   createPodList(manifests.LabelDistributorComponent, corev1.PodRunning),
-		manifests.LabelIngesterComponent:      createPodList(manifests.LabelIngesterComponent, corev1.PodRunning),
-		manifests.LabelQuerierComponent:       createPodList(manifests.LabelQuerierComponent, corev1.PodRunning),
-		manifests.LabelQueryFrontendComponent: createPodList(manifests.LabelQueryFrontendComponent, corev1.PodRunning),
-		manifests.LabelIndexGatewayComponent:  createPodList(manifests.LabelIndexGatewayComponent, corev1.PodRunning),
-		manifests.LabelRulerComponent:         createPodList(manifests.LabelRulerComponent, corev1.PodRunning),
-		manifests.LabelGatewayComponent:       createPodList(manifests.LabelGatewayComponent, corev1.PodRunning),
+		manifests.LabelCompactorComponent:     createPodList(manifests.LabelCompactorComponent, true, corev1.PodRunning),
+		manifests.LabelDistributorComponent:   createPodList(manifests.LabelDistributorComponent, true, corev1.PodRunning),
+		manifests.LabelIngesterComponent:      createPodList(manifests.LabelIngesterComponent, true, corev1.PodRunning),
+		manifests.LabelQuerierComponent:       createPodList(manifests.LabelQuerierComponent, true, corev1.PodRunning),
+		manifests.LabelQueryFrontendComponent: createPodList(manifests.LabelQueryFrontendComponent, true, corev1.PodRunning),
+		manifests.LabelIndexGatewayComponent:  createPodList(manifests.LabelIndexGatewayComponent, true, corev1.PodRunning),
+		manifests.LabelRulerComponent:         createPodList(manifests.LabelRulerComponent, true, corev1.PodRunning),
+		manifests.LabelGatewayComponent:       createPodList(manifests.LabelGatewayComponent, true, corev1.PodRunning),
 	}
 
 	wantStatus := lokiv1.LokiStackStatus{
 		Components: lokiv1.LokiStackComponentStatus{
-			Compactor:     map[corev1.PodPhase][]string{corev1.PodRunning: {"compactor-pod-0"}},
-			Distributor:   map[corev1.PodPhase][]string{corev1.PodRunning: {"distributor-pod-0"}},
-			IndexGateway:  map[corev1.PodPhase][]string{corev1.PodRunning: {"index-gateway-pod-0"}},
-			Ingester:      map[corev1.PodPhase][]string{corev1.PodRunning: {"ingester-pod-0"}},
-			Querier:       map[corev1.PodPhase][]string{corev1.PodRunning: {"querier-pod-0"}},
-			QueryFrontend: map[corev1.PodPhase][]string{corev1.PodRunning: {"query-frontend-pod-0"}},
-			Gateway:       map[corev1.PodPhase][]string{corev1.PodRunning: {"lokistack-gateway-pod-0"}},
-			Ruler:         map[corev1.PodPhase][]string{corev1.PodRunning: {"ruler-pod-0"}},
+			Compactor:     lokiv1.PodStatusMap{lokiv1.PodReady: {"compactor-pod-0"}},
+			Distributor:   lokiv1.PodStatusMap{lokiv1.PodReady: {"distributor-pod-0"}},
+			IndexGateway:  lokiv1.PodStatusMap{lokiv1.PodReady: {"index-gateway-pod-0"}},
+			Ingester:      lokiv1.PodStatusMap{lokiv1.PodReady: {"ingester-pod-0"}},
+			Querier:       lokiv1.PodStatusMap{lokiv1.PodReady: {"querier-pod-0"}},
+			QueryFrontend: lokiv1.PodStatusMap{lokiv1.PodReady: {"query-frontend-pod-0"}},
+			Gateway:       lokiv1.PodStatusMap{lokiv1.PodReady: {"lokistack-gateway-pod-0"}},
+			Ruler:         lokiv1.PodStatusMap{lokiv1.PodReady: {"ruler-pod-0"}},
 		},
 		Storage: lokiv1.LokiStackStorageStatus{},
 		Conditions: []metav1.Condition{


### PR DESCRIPTION
This is a backport of grafana/loki#11968 to 5.7. Implements [LOG-5172](https://issues.redhat.com//browse/LOG-5172).