### PR TITLE
[release-5.8] Backport PR grafana/loki#12164 and grafana/loki#12216

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.8.5
 
+- [12164](https://github.com/grafana/loki/pull/12164) **periklis**: Use safe bearer token authentication to scrape operator metrics
 - [12216](https://github.com/grafana/loki/pull/12216) **xperimental**: Fix duplicate operator metrics due to ServiceMonitor selector
 - [11968](https://github.com/grafana/loki/pull/11968) **xperimental**: Extend status to show difference between running and ready
 

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.8.5
 
+- [12216](https://github.com/grafana/loki/pull/12216) **xperimental**: Fix duplicate operator metrics due to ServiceMonitor selector
 - [11968](https://github.com/grafana/loki/pull/11968) **xperimental**: Extend status to show difference between running and ready
 
 ## Release 5.8.4

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: loki-operator
+    app.kubernetes.io/version: 0.5.0
+  name: loki-operator-controller-manager-metrics-reader

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
@@ -3,9 +3,9 @@ kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/instance: loki-operator-v0.4.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.5.0
+    app.kubernetes.io/version: 0.4.0
   name: loki-operator-controller-manager-metrics-reader

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
@@ -5,6 +5,7 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: loki-operator-metrics
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: loki-operator-v0.4.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: loki-operator-controller-manager-metrics-reader
+  labels:
+    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: loki-operator
+    app.kubernetes.io/version: 0.5.0
+  name: loki-operator-controller-manager-metrics-token
+type: kubernetes.io/service-account-token

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
@@ -4,10 +4,10 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: loki-operator-controller-manager-metrics-reader
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/instance: loki-operator-v0.4.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.5.0
+    app.kubernetes.io/version: 0.4.0
   name: loki-operator-controller-manager-metrics-token
 type: kubernetes.io/service-account-token

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: loki-operator
+    app.kubernetes.io/version: 0.5.0
+  name: loki-operator-controller-manager-read-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-operator-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: loki-operator-controller-manager-metrics-reader
+  namespace: kubernetes-operators

--- a/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -3,11 +3,11 @@ kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/instance: loki-operator-v0.4.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.5.0
+    app.kubernetes.io/version: 0.4.0
   name: loki-operator-controller-manager-read-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/bundle/community-openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -22,4 +22,5 @@ spec:
       serverName: loki-operator-controller-manager-metrics-service.kubernetes-operators.svc
   selector:
     matchLabels:
+      app.kubernetes.io/component: metrics
       app.kubernetes.io/name: loki-operator

--- a/operator/bundle/community-openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -11,14 +11,21 @@ metadata:
   name: loki-operator-metrics-monitor
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  - authorization:
+      credentials:
+        key: token
+        name: loki-operator-controller-manager-metrics-token
+      type: bearer
     interval: 30s
     path: /metrics
     scheme: https
     scrapeTimeout: 10s
     targetPort: 8443
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      ca:
+        secret:
+          key: service-ca.crt
+          name: loki-operator-controller-manager-metrics-token
       serverName: loki-operator-controller-manager-metrics-service.kubernetes-operators.svc
   selector:
     matchLabels:

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.4.0
-    createdAt: "2024-03-04T17:34:37Z"
+    createdAt: "2024-03-14T13:25:52Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -1633,7 +1633,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: default
+        serviceAccountName: loki-operator-controller-manager
       deployments:
       - label:
           app.kubernetes.io/instance: loki-operator-v0.4.0
@@ -1734,6 +1734,7 @@ spec:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
+              serviceAccountName: loki-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:
               - configMap:
@@ -1767,7 +1768,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: default
+        serviceAccountName: loki-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: false

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.4.0
-    createdAt: "2024-03-14T13:25:52Z"
+    createdAt: "2024-03-14T20:38:35Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"

--- a/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
+++ b/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: loki-operator
+    app.kubernetes.io/version: 0.5.0
+  name: loki-operator-controller-manager-metrics-reader

--- a/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
+++ b/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
@@ -3,9 +3,9 @@ kind: ServiceAccount
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/instance: loki-operator-v0.4.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.5.0
+    app.kubernetes.io/version: 0.4.0
   name: loki-operator-controller-manager-metrics-reader

--- a/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operator/bundle/community/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: loki-operator-v0.4.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator

--- a/operator/bundle/community/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operator/bundle/community/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: loki-operator
+    app.kubernetes.io/version: 0.5.0
+  name: loki-operator-controller-manager-read-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-operator-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: loki-operator-controller-manager-metrics-reader
+  namespace: loki-operator

--- a/operator/bundle/community/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operator/bundle/community/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -3,11 +3,11 @@ kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/instance: loki-operator-v0.5.0
+    app.kubernetes.io/instance: loki-operator-v0.4.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator
     app.kubernetes.io/part-of: loki-operator
-    app.kubernetes.io/version: 0.5.0
+    app.kubernetes.io/version: 0.4.0
   name: loki-operator-controller-manager-read-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.4.0
-    createdAt: "2024-03-14T13:25:49Z"
+    createdAt: "2024-03-14T20:38:33Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.4.0
-    createdAt: "2024-03-04T17:34:34Z"
+    createdAt: "2024-03-14T13:25:49Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -1613,7 +1613,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: default
+        serviceAccountName: loki-operator-controller-manager
       deployments:
       - label:
           app.kubernetes.io/instance: loki-operator-v0.4.0
@@ -1703,6 +1703,7 @@ spec:
                 kubernetes.io/os: linux
               securityContext:
                 runAsNonRoot: true
+              serviceAccountName: loki-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:
               - name: webhook-cert
@@ -1735,7 +1736,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: default
+        serviceAccountName: loki-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: false

--- a/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: loki-operator-0.1.0
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: cluster-logging
+    app.kubernetes.io/version: 0.1.0
+  name: loki-operator-controller-manager-metrics-reader

--- a/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
@@ -5,6 +5,7 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: loki-operator-metrics
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: loki-operator-0.1.0
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator

--- a/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: loki-operator-controller-manager-metrics-reader
+  labels:
+    app.kubernetes.io/instance: loki-operator-0.1.0
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: cluster-logging
+    app.kubernetes.io/version: 0.1.0
+  name: loki-operator-controller-manager-metrics-token
+type: kubernetes.io/service-account-token

--- a/operator/bundle/openshift/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: loki-operator-0.1.0
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: cluster-logging
+    app.kubernetes.io/version: 0.1.0
+  name: loki-operator-controller-manager-read-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-operator-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: loki-operator-controller-manager-metrics-reader
+  namespace: openshift-operators-redhat

--- a/operator/bundle/openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -11,14 +11,21 @@ metadata:
   name: loki-operator-metrics-monitor
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  - authorization:
+      credentials:
+        key: token
+        name: loki-operator-controller-manager-metrics-token
+      type: bearer
     interval: 30s
     path: /metrics
     scheme: https
     scrapeTimeout: 10s
     targetPort: 8443
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      ca:
+        secret:
+          key: service-ca.crt
+          name: loki-operator-controller-manager-metrics-token
       serverName: loki-operator-controller-manager-metrics-service.openshift-operators-redhat.svc
   selector:
     matchLabels:

--- a/operator/bundle/openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -22,4 +22,5 @@ spec:
       serverName: loki-operator-controller-manager-metrics-service.openshift-operators-redhat.svc
   selector:
     matchLabels:
+      app.kubernetes.io/component: metrics
       app.kubernetes.io/name: loki-operator

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -1618,7 +1618,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: default
+        serviceAccountName: loki-operator-controller-manager
       deployments:
       - label:
           app.kubernetes.io/instance: loki-operator-0.1.0
@@ -1719,6 +1719,7 @@ spec:
                 runAsNonRoot: true
                 seccompProfile:
                   type: RuntimeDefault
+              serviceAccountName: loki-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:
               - configMap:
@@ -1752,7 +1753,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: default
+        serviceAccountName: loki-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: false

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2024-03-14T13:25:55Z"
+    createdAt: "2024-03-14T20:38:36Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2024-03-04T17:34:40Z"
+    createdAt: "2024-03-14T13:25:55Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -39,4 +39,5 @@ spec:
           periodSeconds: 10
       nodeSelector:
         kubernetes.io/os: linux
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/operator/config/overlays/community-openshift/prometheus_service_monitor_patch.yaml
+++ b/operator/config/overlays/community-openshift/prometheus_service_monitor_patch.yaml
@@ -6,12 +6,19 @@ metadata:
   name: metrics-monitor
 spec:
   endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      path: /metrics
+    - path: /metrics
       targetPort: 8443
       scheme: https
       interval: 30s
       scrapeTimeout: 10s
+      authorization:
+        type: bearer
+        credentials:
+          key: token
+          name: loki-operator-controller-manager-metrics-token
       tlsConfig:
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        ca:
+          secret:
+            key: service-ca.crt
+            name: loki-operator-controller-manager-metrics-token
         serverName: loki-operator-controller-manager-metrics-service.kubernetes-operators.svc

--- a/operator/config/overlays/openshift/kustomization.yaml
+++ b/operator/config/overlays/openshift/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../manager
 - ../../webhook
 - ../../prometheus
+- manager_metrics_secret_token.yaml
 
 # Adds namespace to all resources.
 namespace: openshift-operators-redhat

--- a/operator/config/overlays/openshift/manager_metrics_secret_token.yaml
+++ b/operator/config/overlays/openshift/manager_metrics_secret_token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: controller-manager-metrics-token
+  annotations:
+    kubernetes.io/service-account.name: loki-operator-controller-manager-metrics-reader
+type: kubernetes.io/service-account-token

--- a/operator/config/overlays/openshift/prometheus_service_monitor_patch.yaml
+++ b/operator/config/overlays/openshift/prometheus_service_monitor_patch.yaml
@@ -6,12 +6,19 @@ metadata:
   name: metrics-monitor
 spec:
   endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      path: /metrics
+    - path: /metrics
       targetPort: 8443
       scheme: https
       interval: 30s
       scrapeTimeout: 10s
+      authorization:
+        type: bearer
+        credentials:
+          key: token
+          name: loki-operator-controller-manager-metrics-token
       tlsConfig:
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        ca:
+          secret:
+            key: service-ca.crt
+            name: loki-operator-controller-manager-metrics-token
         serverName: loki-operator-controller-manager-metrics-service.openshift-operators-redhat.svc

--- a/operator/config/prometheus/monitor.yaml
+++ b/operator/config/prometheus/monitor.yaml
@@ -10,3 +10,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: loki-operator
+      app.kubernetes.io/component: metrics

--- a/operator/config/rbac/auth_proxy_client_clusterrolebinding.yaml
+++ b/operator/config/rbac/auth_proxy_client_clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: controller-manager-read-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: leader-election-role
+  kind: ClusterRole
+  name: metrics-reader
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: controller-manager-metrics-reader
   namespace: system

--- a/operator/config/rbac/auth_proxy_client_serviceaccount.yaml
+++ b/operator/config/rbac/auth_proxy_client_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager-metrics-reader
+  namespace: system

--- a/operator/config/rbac/auth_proxy_role_binding.yaml
+++ b/operator/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/operator/config/rbac/auth_proxy_service.yaml
+++ b/operator/config/rbac/auth_proxy_service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/component: metrics
   name: controller-manager-metrics-service
 spec:
   ports:

--- a/operator/config/rbac/kustomization.yaml
+++ b/operator/config/rbac/kustomization.yaml
@@ -7,5 +7,8 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- auth_proxy_client_clusterrolebinding.yaml
+- auth_proxy_client_serviceaccount.yaml
 - prometheus_role.yaml
 - prometheus_role_binding.yaml
+- serviceaccount.yaml

--- a/operator/config/rbac/role_binding.yaml
+++ b/operator/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: lokistack-manager
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/operator/config/rbac/serviceaccount.yaml
+++ b/operator/config/rbac/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
Backporting PRs for operator metrics support in UWM environments in `release-5.8`

Refs: [LOG-5240](https://issues.redhat.com//browse/LOG-5240), [LOG-5250](https://issues.redhat.com//browse/LOG-5250)