### PR TITLE
[release-5.6] Backport PR grafana/loki#12164 and grafana/loki#12216

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.17
 
+- [12164](https://github.com/grafana/loki/pull/12164) **periklis**: Use safe bearer token authentication to scrape operator metrics
 - [12216](https://github.com/grafana/loki/pull/12216) **xperimental**: Fix duplicate operator metrics due to ServiceMonitor selector
 - [11824](https://github.com/grafana/loki/pull/11824) **xperimental**: Improve messages for errors in storage secret
 

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.17
 
+- [12216](https://github.com/grafana/loki/pull/12216) **xperimental**: Fix duplicate operator metrics due to ServiceMonitor selector
 - [11824](https://github.com/grafana/loki/pull/11824) **xperimental**: Improve messages for errors in storage secret
 
 ## Release 5.6.16

--- a/operator/bundle/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
+++ b/operator/bundle/manifests/loki-operator-controller-manager-metrics-reader_v1_serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: cluster-logging
+    app.kubernetes.io/version: 0.0.1
+  name: loki-operator-controller-manager-metrics-reader

--- a/operator/bundle/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operator/bundle/manifests/loki-operator-controller-manager-metrics-service_v1_service.yaml
@@ -5,6 +5,7 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: loki-operator-metrics
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: loki-operator-v0.0.1
     app.kubernetes.io/managed-by: operator-lifecycle-manager
     app.kubernetes.io/name: loki-operator

--- a/operator/bundle/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
+++ b/operator/bundle/manifests/loki-operator-controller-manager-metrics-token_v1_secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: loki-operator-controller-manager-metrics-reader
+  labels:
+    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: cluster-logging
+    app.kubernetes.io/version: 0.0.1
+  name: loki-operator-controller-manager-metrics-token
+type: kubernetes.io/service-account-token

--- a/operator/bundle/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/operator/bundle/manifests/loki-operator-controller-manager-read-metrics_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: loki-operator-v0.0.1
+    app.kubernetes.io/managed-by: operator-lifecycle-manager
+    app.kubernetes.io/name: loki-operator
+    app.kubernetes.io/part-of: cluster-logging
+    app.kubernetes.io/version: 0.0.1
+  name: loki-operator-controller-manager-read-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: loki-operator-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: loki-operator-controller-manager-metrics-reader
+  namespace: openshift-operators-redhat

--- a/operator/bundle/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -11,14 +11,21 @@ metadata:
   name: loki-operator-metrics-monitor
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  - authorization:
+      credentials:
+        key: token
+        name: loki-operator-controller-manager-metrics-token
+      type: bearer
     interval: 30s
     path: /metrics
     scheme: https
     scrapeTimeout: 10s
     targetPort: 8443
     tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      ca:
+        secret:
+          key: service-ca.crt
+          name: loki-operator-controller-manager-metrics-token
       serverName: loki-operator-controller-manager-metrics-service.openshift-operators-redhat.svc
   selector:
     matchLabels:

--- a/operator/bundle/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/operator/bundle/manifests/loki-operator-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -22,4 +22,5 @@ spec:
       serverName: loki-operator-controller-manager-metrics-service.openshift-operators-redhat.svc
   selector:
     matchLabels:
+      app.kubernetes.io/component: metrics
       app.kubernetes.io/name: loki-operator

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1294,7 +1294,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: default
+        serviceAccountName: loki-operator-controller-manager
       deployments:
       - label:
           app.kubernetes.io/instance: loki-operator-v0.0.1
@@ -1393,6 +1393,7 @@ spec:
                 kubernetes.io/os: linux
               securityContext:
                 runAsNonRoot: true
+              serviceAccountName: loki-operator-controller-manager
               terminationGracePeriodSeconds: 10
               volumes:
               - configMap:
@@ -1426,7 +1427,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: default
+        serviceAccountName: loki-operator-controller-manager
     strategy: deployment
   installModes:
   - supported: false

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -44,6 +44,7 @@ spec:
           periodSeconds: 10
       nodeSelector:
         kubernetes.io/os: linux
+      serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       securityContext:
         runAsNonRoot: true

--- a/operator/config/overlays/openshift/kustomization.yaml
+++ b/operator/config/overlays/openshift/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../manager
 - ../../webhook
 - ../../prometheus
+- manager_metrics_secret_token.yaml
 
 # Adds namespace to all resources.
 namespace: openshift-operators-redhat

--- a/operator/config/overlays/openshift/manager_metrics_secret_token.yaml
+++ b/operator/config/overlays/openshift/manager_metrics_secret_token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: controller-manager-metrics-token
+  annotations:
+    kubernetes.io/service-account.name: loki-operator-controller-manager-metrics-reader
+type: kubernetes.io/service-account-token

--- a/operator/config/overlays/openshift/prometheus_service_monitor_patch.yaml
+++ b/operator/config/overlays/openshift/prometheus_service_monitor_patch.yaml
@@ -6,12 +6,19 @@ metadata:
   name: metrics-monitor
 spec:
   endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      path: /metrics
+    - path: /metrics
       targetPort: 8443
       scheme: https
       interval: 30s
       scrapeTimeout: 10s
+      authorization:
+        type: bearer
+        credentials:
+          key: token
+          name: loki-operator-controller-manager-metrics-token
       tlsConfig:
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        ca:
+          secret:
+            key: service-ca.crt
+            name: loki-operator-controller-manager-metrics-token
         serverName: loki-operator-controller-manager-metrics-service.openshift-operators-redhat.svc

--- a/operator/config/overlays/production/prometheus_service_monitor_patch.yaml
+++ b/operator/config/overlays/production/prometheus_service_monitor_patch.yaml
@@ -7,12 +7,19 @@ metadata:
   name: metrics-monitor
 spec:
   endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      path: /metrics
+    - path: /metrics
       targetPort: 8443
       scheme: https
       interval: 30s
       scrapeTimeout: 10s
+      authorization:
+        type: bearer
+        credentials:
+          key: token
+          name: loki-operator-controller-manager-metrics-token
       tlsConfig:
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        serverName: loki-operator-controller-manager-metrics-service.loki-operator.svc
+        ca:
+          secret:
+            key: service-ca.crt
+            name: loki-operator-controller-manager-metrics-token
+        serverName: loki-operator-controller-manager-metrics-service.kubernetes-operators.svc

--- a/operator/config/prometheus/monitor.yaml
+++ b/operator/config/prometheus/monitor.yaml
@@ -10,3 +10,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: loki-operator
+      app.kubernetes.io/component: metrics

--- a/operator/config/rbac/auth_proxy_client_clusterrolebinding.yaml
+++ b/operator/config/rbac/auth_proxy_client_clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: leader-election-rolebinding
+  name: controller-manager-read-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: leader-election-role
+  kind: ClusterRole
+  name: metrics-reader
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: controller-manager-metrics-reader
   namespace: system

--- a/operator/config/rbac/auth_proxy_client_serviceaccount.yaml
+++ b/operator/config/rbac/auth_proxy_client_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager-metrics-reader
+  namespace: system

--- a/operator/config/rbac/auth_proxy_role_binding.yaml
+++ b/operator/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/operator/config/rbac/auth_proxy_service.yaml
+++ b/operator/config/rbac/auth_proxy_service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/component: metrics
   name: controller-manager-metrics-service
 spec:
   ports:

--- a/operator/config/rbac/kustomization.yaml
+++ b/operator/config/rbac/kustomization.yaml
@@ -7,5 +7,8 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+- auth_proxy_client_clusterrolebinding.yaml
+- auth_proxy_client_serviceaccount.yaml
 - prometheus_role.yaml
 - prometheus_role_binding.yaml
+- serviceaccount.yaml

--- a/operator/config/rbac/role_binding.yaml
+++ b/operator/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: lokistack-manager
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: controller-manager
   namespace: system

--- a/operator/config/rbac/serviceaccount.yaml
+++ b/operator/config/rbac/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: system


### PR DESCRIPTION
Backporting PRs for operator metrics support in UWM environments in `release-5.6`

Refs: [LOG-5242](https://issues.redhat.com//browse/LOG-5242), [LOG-5252](https://issues.redhat.com//browse/LOG-5252)