### PR TITLE
LOG-5272: Bump max OpenShift version to 4.16

### DIFF
--- a/operator/bundle/openshift/metadata/properties.yaml
+++ b/operator/bundle/openshift/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.15
+    value: 4.16


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Max OpenShift Version to `4.16` to keep existing installations from raising `IncompatibleOperatorsInstalled` alerts.
