### PR TITLE
[release-5.8] Configure Loki to use virtual-host-style URLs for S3 AWS endpoints

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Main
 
+- [12469](https://github.com/grafana/loki/pull/12469) **btaani**: Configure Loki to use virtual-host-style URLs for S3 AWS endpoints
+
 ## Release 5.8.6
 
 - [12181](https://github.com/grafana/loki/pull/12181) **btaani**: Improve validation of provided S3 storage configuration

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## Main
 
-- [12469](https://github.com/grafana/loki/pull/12469) **btaani**: Configure Loki to use virtual-host-style URLs for S3 AWS endpoints
-
 ## Release 5.8.6
 
+- [12469](https://github.com/grafana/loki/pull/12469) **btaani**: Configure Loki to use virtual-host-style URLs for S3 AWS endpoints
 - [12181](https://github.com/grafana/loki/pull/12181) **btaani**: Improve validation of provided S3 storage configuration
 - [12370](https://github.com/grafana/loki/pull/12370) **periklis**: Update Loki operand to v2.9.6
 

--- a/operator/internal/handlers/internal/storage/secrets.go
+++ b/operator/internal/handlers/internal/storage/secrets.go
@@ -200,7 +200,15 @@ func extractS3ConfigSecret(s *corev1.Secret) (*storage.S3StorageConfig, error) {
 		return nil, fmt.Errorf("%w: %s", errSecretMissingField, storage.KeyAWSAccessKeySecret)
 	}
 
-	return cfg, nil
+	forcePathStyle := !strings.HasSuffix(string(endpoint), awsEndpointSuffix)
+
+	return &storage.S3StorageConfig{
+		Endpoint:       string(endpoint),
+		Buckets:        string(buckets),
+		Region:         string(region),
+		SSE:            sseCfg,
+		ForcePathStyle: forcePathStyle,
+	}, nil
 }
 
 func validateS3Endpoint(endpoint string, region string) error {

--- a/operator/internal/handlers/internal/storage/secrets_test.go
+++ b/operator/internal/handlers/internal/storage/secrets_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lokiv1 "github.com/grafana/loki/operator/apis/loki/v1"
+	"github.com/grafana/loki/operator/internal/manifests/storage"
 )
 
 func TestHashSecretData(t *testing.T) {
@@ -623,6 +624,62 @@ func TestAlibabaCloudExtract(t *testing.T) {
 			} else {
 				require.EqualError(t, err, tst.wantError)
 			}
+		})
+	}
+}
+
+func TestS3Extract_S3ForcePathStyle(t *testing.T) {
+	tt := []struct {
+		desc        string
+		secret      *corev1.Secret
+		wantOptions *storage.S3StorageConfig
+	}{
+		{
+			desc: "aws s3 endpoint",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Data: map[string][]byte{
+					"endpoint":          []byte("https://s3.region.amazonaws.com"),
+					"region":            []byte("region"),
+					"bucketnames":       []byte("this,that"),
+					"access_key_id":     []byte("id"),
+					"access_key_secret": []byte("secret"),
+				},
+			},
+			wantOptions: &storage.S3StorageConfig{
+				Endpoint: "https://s3.region.amazonaws.com",
+				Region:   "region",
+				Buckets:  "this,that",
+			},
+		},
+		{
+			desc: "non-aws s3 endpoint",
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Data: map[string][]byte{
+					"endpoint":          []byte("https://test.default.svc.cluster.local:9000"),
+					"region":            []byte("region"),
+					"bucketnames":       []byte("this,that"),
+					"access_key_id":     []byte("id"),
+					"access_key_secret": []byte("secret"),
+				},
+			},
+			wantOptions: &storage.S3StorageConfig{
+				Endpoint:       "https://test.default.svc.cluster.local:9000",
+				Region:         "region",
+				Buckets:        "this,that",
+				ForcePathStyle: true,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			options, err := extractS3ConfigSecret(tc.secret)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantOptions, options)
 		})
 	}
 }

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -24,7 +24,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -238,9 +238,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -274,7 +275,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -519,9 +520,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -601,9 +603,10 @@ func TestBuild_ConfigAndRuntimeConfig_CreateLokiConfigFailed(t *testing.T) {
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -631,7 +634,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -946,9 +949,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -982,7 +986,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -1298,9 +1302,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -1334,7 +1339,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -1680,9 +1685,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -1716,7 +1722,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -2004,9 +2010,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -2043,7 +2050,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -2419,9 +2426,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -2455,7 +2463,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -2758,9 +2766,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -2794,7 +2803,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -3247,9 +3256,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -3283,7 +3293,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -3500,9 +3510,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -3536,7 +3547,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -3755,9 +3766,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -3791,7 +3803,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -4008,9 +4020,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 			},
 			Schemas: []lokiv1.ObjectStorageSchema{
 				{
@@ -4044,7 +4057,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -4294,9 +4307,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 
 				SSE: storage.S3SSEConfig{
 					Type:                 storage.SSEKMSType,
@@ -4335,7 +4349,7 @@ chunk_store_config:
 common:
   storage:
     s3:
-      s3: http://test.default.svc.cluster.local.:9000
+      endpoint: http://test.default.svc.cluster.local.:9000
       bucketnames: loki
       region: us-east
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -4582,9 +4596,10 @@ overrides:
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
 			S3: &storage.S3StorageConfig{
-				Endpoint: "http://test.default.svc.cluster.local.:9000",
-				Region:   "us-east",
-				Buckets:  "loki",
+				Endpoint:       "http://test.default.svc.cluster.local.:9000",
+				Region:         "us-east",
+				Buckets:        "loki",
+				ForcePathStyle: true,
 
 				SSE: storage.S3SSEConfig{
 					Type:                 storage.SSES3Type,

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -24,7 +24,7 @@ common:
     {{- end }}
     {{- with .ObjectStorage.S3 }}
     s3:
-      s3: {{ .Endpoint }}
+      endpoint: {{ .Endpoint }}
       bucketnames: {{ .Buckets }}
       region: {{ .Region }}
       access_key_id: ${AWS_ACCESS_KEY_ID}
@@ -42,7 +42,9 @@ common:
         {{- end}}
       {{- end }}
       {{- end }}
+       {{- if .ForcePathStyle  }}
       s3forcepathstyle: true
+      {{- end}}
     {{- end }}
     {{- with .ObjectStorage.Swift }}
     swift:

--- a/operator/internal/manifests/storage/options.go
+++ b/operator/internal/manifests/storage/options.go
@@ -35,10 +35,11 @@ type GCSStorageConfig struct {
 
 // S3StorageConfig for S3 storage config
 type S3StorageConfig struct {
-	Endpoint string
-	Region   string
-	Buckets  string
-	SSE      S3SSEConfig
+	Endpoint       string
+	Region         string
+	Buckets        string
+	SSE            S3SSEConfig
+	ForcePathStyle bool
 }
 
 type S3SSEType string


### PR DESCRIPTION
**What this PR does / why we need it**:
Change Loki's configuration to use [virtual-host-style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access) instead of path-style URLs when the object storage endpoint is AWS S3.

**Which issue(s) this PR fixes**:
Fixes [LOG-5402](https://issues.redhat.com/browse/LOG-5402)

**Special notes for your reviewer**:

**Checklist**
- [x] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [x] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] For Helm chart changes bump the Helm chart version in `production/helm/loki/Chart.yaml` and update `production/helm/loki/CHANGELOG.md` and `production/helm/loki/README.md`. [Example PR](https://github.com/grafana/loki/commit/d10549e3ece02120974929894ee333d07755d213)
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
