### PR TITLE
[release-5.7] Backport PR grafana/loki#12874

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.7.14
 
+- [12874](https://github.com/grafana/loki/pull/12874) **periklis**: chore(operator): Update Loki operand to v2.9.8
 - [12698](https://github.com/grafana/loki/pull/12698) **periklis**: chore(deps): bump golang.org/x/net from 0.21.0 to 0.23.0 in /operator
 - [12503](https://github.com/grafana/loki/pull/12503) **periklis**: fix(operator): Bump golang builder to 1.21.9
 

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2024-04-04T12:36:23Z"
+    createdAt: "2024-05-03T18:29:41Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"
@@ -1544,7 +1544,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: docker.io/grafana/loki:2.9.6
+                  value: docker.io/grafana/loki:2.9.8
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1666,7 +1666,7 @@ spec:
   provider:
     name: Grafana Loki SIG Operator
   relatedImages:
-  - image: docker.io/grafana/loki:2.9.6
+  - image: docker.io/grafana/loki:2.9.8
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:main-99acb9b
-    createdAt: "2024-04-04T12:36:22Z"
+    createdAt: "2024-05-03T18:29:39Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1524,7 +1524,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: docker.io/grafana/loki:2.9.6
+                  value: docker.io/grafana/loki:2.9.8
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1641,7 +1641,7 @@ spec:
   provider:
     name: Grafana Loki SIG Operator
   relatedImages:
-  - image: docker.io/grafana/loki:2.9.6
+  - image: docker.io/grafana/loki:2.9.8
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:v0.1.0
-    createdAt: "2024-04-04T12:36:25Z"
+    createdAt: "2024-05-03T18:29:42Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -1529,7 +1529,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: quay.io/openshift-logging/loki:v2.9.6
+                  value: quay.io/openshift-logging/loki:v2.9.8
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1651,7 +1651,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: quay.io/openshift-logging/loki:v2.9.6
+  - image: quay.io/openshift-logging/loki:v2.9.8
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/config/overlays/community-openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/community-openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.9.6
+            value: docker.io/grafana/loki:2.9.8
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/config/overlays/community/manager_related_image_patch.yaml
+++ b/operator/config/overlays/community/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.9.6
+            value: docker.io/grafana/loki:2.9.8
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/config/overlays/development/manager_related_image_patch.yaml
+++ b/operator/config/overlays/development/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.9.6
+            value: docker.io/grafana/loki:2.9.8
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/config/overlays/openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: quay.io/openshift-logging/loki:v2.9.6
+            value: quay.io/openshift-logging/loki:v2.9.8
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/docs/operator/compatibility.md
+++ b/operator/docs/operator/compatibility.md
@@ -39,3 +39,4 @@ The versions of Loki compatible to be run with the Loki Operator are:
 * v2.9.3
 * v2.9.4
 * v2.9.6
+* v2.9.8

--- a/operator/hack/addons_dev.yaml
+++ b/operator/hack/addons_dev.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.9.6-amd64
+          image: docker.io/grafana/logcli:2.9.8-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -73,7 +73,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.9.6
+          image: docker.io/grafana/promtail:2.9.8
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/hack/addons_ocp.yaml
+++ b/operator/hack/addons_ocp.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.9.6-amd64
+          image: docker.io/grafana/logcli:2.9.8-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.9.6
+          image: docker.io/grafana/promtail:2.9.8
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -58,7 +58,7 @@ const (
 	EnvRelatedImageGateway = "RELATED_IMAGE_GATEWAY"
 
 	// DefaultContainerImage declares the default fallback for loki image.
-	DefaultContainerImage = "docker.io/grafana/loki:2.9.6"
+	DefaultContainerImage = "docker.io/grafana/loki:2.9.8"
 
 	// DefaultLokiStackGatewayImage declares the default image for lokiStack-gateway.
 	DefaultLokiStackGatewayImage = "quay.io/observatorium/api:latest"


### PR DESCRIPTION
Backport Loki operand bump to `v2.9.8` to `release-5.7`.

Refs: [LOG-5504](https://issues.redhat.com//browse/LOG-5504)