### PR TITLE
LOG-5617: Use a minimum value for replay memory ceiling

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Main
 
+## Release 5.6.20
+
+- [13066](https://github.com/grafana/loki/pull/13066) **xperimental**: Use a minimum value for replay memory ceiling
+
 ## Release 5.6.19
 
 - [12874](https://github.com/grafana/loki/pull/12874) **periklis**: chore(operator): Update Loki operand to v2.9.8

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -67,7 +67,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 536870912
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -231,7 +231,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 0,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -317,7 +317,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -498,7 +498,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -579,7 +579,7 @@ func TestBuild_ConfigAndRuntimeConfig_CreateLokiConfigFailed(t *testing.T) {
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -659,7 +659,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -924,7 +924,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -1010,7 +1010,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -1276,7 +1276,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -1362,7 +1362,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -1658,7 +1658,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -1747,7 +1747,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -1958,7 +1958,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -2047,7 +2047,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -2373,7 +2373,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -2473,7 +2473,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -2712,7 +2712,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -2799,7 +2799,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -2965,7 +2965,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,
@@ -3053,7 +3053,7 @@ ingester:
   wal:
     enabled: true
     dir: /tmp/wal
-    replay_memory_ceiling: 2500
+    replay_memory_ceiling: 2147483648
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
@@ -3220,7 +3220,7 @@ overrides:
 		},
 		WriteAheadLog: WriteAheadLog{
 			Directory:             "/tmp/wal",
-			IngesterMemoryRequest: 5000,
+			IngesterMemoryRequest: 4 * 1024 * 1024 * 1024,
 		},
 		ObjectStorage: storage.Options{
 			SharedStore: lokiv1.ObjectStorageSecretS3,

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -181,10 +181,20 @@ type WriteAheadLog struct {
 	IngesterMemoryRequest int64
 }
 
+const (
+	// minimumReplayCeiling contains the minimum value that will be used for the replay_memory_ceiling.
+	// It is set, so that even when the ingester has a low memory request, the replay will not flush each block
+	// on its own.
+	minimumReplayCeiling = 512 * 1024 * 1024
+)
+
 // ReplayMemoryCeiling calculates 50% of the ingester memory
 // for the ingester to use for the write-ahead-log capbability.
 func (w WriteAheadLog) ReplayMemoryCeiling() string {
 	value := int64(math.Ceil(float64(w.IngesterMemoryRequest) * float64(0.5)))
+	if value < minimumReplayCeiling {
+		value = minimumReplayCeiling
+	}
 	return fmt.Sprintf("%d", value)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a backport of grafana/loki#13066 to `release-5.6`.

**Which issue(s) this PR fixes**:

Fixes [LOG-5617](https://issues.redhat.com//browse/LOG-5617)
