### PR TITLE
[release-5.9] Backport PR grafana/loki#13299

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Main
 
+## Release 5.9.4
+
+- [13299](https://github.com/grafana/loki/pull/13299) **periklis**: fix(operator): Watch for CredentialsRequests on CCOAuthEnv only
+
 ## Release 5.9.3
 
 - [13066](https://github.com/grafana/loki/pull/13066) **xperimental**: Use a minimum value for replay memory ceiling

--- a/operator/controllers/loki/lokistack_controller.go
+++ b/operator/controllers/loki/lokistack_controller.go
@@ -221,9 +221,11 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 	}
 
 	if r.FeatureGates.OpenShift.Enabled {
-		bld = bld.
-			Owns(&routev1.Route{}, updateOrDeleteOnlyPred).
-			Owns(&cloudcredentialv1.CredentialsRequest{}, updateOrDeleteOnlyPred)
+		bld = bld.Owns(&routev1.Route{}, updateOrDeleteOnlyPred)
+
+		if r.FeatureGates.OpenShift.TokenCCOAuthEnv {
+			bld = bld.Owns(&cloudcredentialv1.CredentialsRequest{}, updateOrDeleteOnlyPred)
+		}
 
 		if r.FeatureGates.OpenShift.ClusterTLSPolicy {
 			bld = bld.Watches(&openshiftconfigv1.APIServer{}, r.enqueueAllLokiStacksHandler(), updateOrDeleteOnlyPred)

--- a/operator/controllers/loki/lokistack_controller_test.go
+++ b/operator/controllers/loki/lokistack_controller_test.go
@@ -161,7 +161,7 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 		{
 			obj:           &routev1.Route{},
 			index:         10,
-			ownCallsCount: 12,
+			ownCallsCount: 11,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
 					Enabled: true,
@@ -175,7 +175,8 @@ func TestLokiStackController_RegisterOwnedResourcesForUpdateOrDeleteOnly(t *test
 			ownCallsCount: 12,
 			featureGates: configv1.FeatureGates{
 				OpenShift: configv1.OpenShiftFeatureGates{
-					Enabled: true,
+					Enabled:         true,
+					TokenCCOAuthEnv: true,
 				},
 			},
 			pred: updateOrDeleteOnlyPred,


### PR DESCRIPTION
Backport fix to enable `release-5.9` installations on CRC.

Refs: [LOG-5701](https://issues.redhat.com//browse/LOG-5701)