### PR TITLE
[release-5.8] Backport PR grafana/loki#13422

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.8.9
 
+- [13422](https://github.com/grafana/loki/pull/13422) **periklis** feat(operator): Update Loki operand to v3.1.0
 - [13369](https://github.com/grafana/loki/pull/13369) **jatinsu**: feat(operator): Add support for the volume API
 
 ## Release 5.8.8

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.4.0
-    createdAt: "2024-07-03T08:01:34Z"
+    createdAt: "2024-07-05T17:56:55Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     features.operators.openshift.io/disconnected: "true"
@@ -1681,7 +1681,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: docker.io/grafana/loki:2.9.8
+                  value: docker.io/grafana/loki:3.1.0
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1805,7 +1805,7 @@ spec:
   provider:
     name: Grafana Loki SIG Operator
   relatedImages:
-  - image: docker.io/grafana/loki:2.9.8
+  - image: docker.io/grafana/loki:3.1.0
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: docker.io/grafana/loki-operator:0.4.0
-    createdAt: "2024-07-03T08:01:33Z"
+    createdAt: "2024-07-05T17:56:53Z"
     description: The Community Loki Operator provides Kubernetes native deployment
       and management of Loki and related logging components.
     operators.operatorframework.io/builder: operator-sdk-unknown
@@ -1661,7 +1661,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: docker.io/grafana/loki:2.9.8
+                  value: docker.io/grafana/loki:3.1.0
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1773,7 +1773,7 @@ spec:
   provider:
     name: Grafana Loki SIG Operator
   relatedImages:
-  - image: docker.io/grafana/loki:2.9.8
+  - image: docker.io/grafana/loki:3.1.0
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -150,7 +150,7 @@ metadata:
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
     containerImage: quay.io/openshift-logging/loki-operator:0.1.0
-    createdAt: "2024-07-03T08:01:36Z"
+    createdAt: "2024-07-05T17:56:56Z"
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -1666,7 +1666,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: quay.io/openshift-logging/loki:v2.9.8
+                  value: quay.io/openshift-logging/loki:v3.1.0
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1790,7 +1790,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: quay.io/openshift-logging/loki:v2.9.8
+  - image: quay.io/openshift-logging/loki:v3.1.0
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/config/overlays/community-openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/community-openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.9.8
+            value: docker.io/grafana/loki:3.1.0
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/config/overlays/community/manager_related_image_patch.yaml
+++ b/operator/config/overlays/community/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.9.8
+            value: docker.io/grafana/loki:3.1.0
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/config/overlays/development/manager_related_image_patch.yaml
+++ b/operator/config/overlays/development/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.9.8
+            value: docker.io/grafana/loki:3.1.0
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/config/overlays/openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: quay.io/openshift-logging/loki:v2.9.8
+            value: quay.io/openshift-logging/loki:v3.1.0
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/docs/operator/compatibility.md
+++ b/operator/docs/operator/compatibility.md
@@ -40,3 +40,4 @@ The versions of Loki compatible to be run with the Loki Operator are:
 * v2.9.4
 * v2.9.6
 * v2.9.8
+* v3.1.0

--- a/operator/hack/addons_dev.yaml
+++ b/operator/hack/addons_dev.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.9.8-amd64
+          image: docker.io/grafana/logcli:3.1.0-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -73,7 +73,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.9.8
+          image: docker.io/grafana/promtail:3.1.0
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/hack/addons_ocp.yaml
+++ b/operator/hack/addons_ocp.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.9.8-amd64
+          image: docker.io/grafana/logcli:3.1.0-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.9.8
+          image: docker.io/grafana/promtail:3.1.0
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -49,7 +49,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -64,7 +63,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -91,7 +89,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -165,7 +162,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -303,7 +299,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -318,7 +313,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -345,7 +339,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -419,7 +412,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -665,7 +657,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -680,7 +671,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -707,7 +697,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -835,7 +824,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -1020,7 +1008,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -1035,7 +1022,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -1062,7 +1048,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -1190,7 +1175,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -1376,7 +1360,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -1391,7 +1374,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -1418,7 +1400,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -1559,7 +1540,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -1765,7 +1745,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -1780,7 +1759,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -1807,7 +1785,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -1886,7 +1863,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -2093,7 +2069,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -2108,7 +2083,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -2135,7 +2109,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -2289,7 +2262,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -2523,7 +2495,6 @@ frontend_worker:
     tls_server_name: query-frontend-grpc.svc
     tls_cipher_suites: cipher1,cipher2
     tls_min_version: VersionTLS12
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -2538,7 +2509,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -2572,7 +2542,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -2675,7 +2644,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
       grpc_client_config:
@@ -2852,7 +2820,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -2867,7 +2834,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -2894,7 +2860,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -3048,7 +3013,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -3346,7 +3310,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -3361,7 +3324,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -3388,7 +3350,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -3463,7 +3424,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -3603,7 +3563,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -3619,7 +3578,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -3646,7 +3604,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -3721,7 +3678,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -3863,7 +3819,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -3878,7 +3833,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -3905,7 +3859,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -3979,7 +3932,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -4123,7 +4075,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -4138,7 +4089,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -4165,7 +4115,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -4239,7 +4188,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -4415,7 +4363,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -4430,7 +4377,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -4457,7 +4403,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -4531,7 +4476,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -121,7 +121,6 @@ frontend_worker:
     tls_cipher_suites: {{ .TLS.CipherSuitesString }}
     tls_min_version: {{ .TLS.MinTLSVersion }}
 {{- end }}
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -139,7 +138,6 @@ ingester:
     {{- end}}
     ring:
       replication_factor: {{ .Stack.Replication.Factor }}
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: {{ .WriteAheadLog.Directory }}
@@ -175,7 +173,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -477,7 +474,6 @@ storage_config:
     cache_location: {{ .StorageDirectory }}/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: {{ .ObjectStorage.SharedStore }}
     index_gateway_client:
       server_address: dns:///{{ .IndexGateway.FQDN }}:{{ .IndexGateway.Port }}
 {{- if .Gates.GRPCEncryption }}

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -59,7 +59,7 @@ const (
 	EnvRelatedImageGateway = "RELATED_IMAGE_GATEWAY"
 
 	// DefaultContainerImage declares the default fallback for loki image.
-	DefaultContainerImage = "docker.io/grafana/loki:2.9.8"
+	DefaultContainerImage = "docker.io/grafana/loki:3.1.0"
 
 	// DefaultLokiStackGatewayImage declares the default image for lokiStack-gateway.
 	DefaultLokiStackGatewayImage = "quay.io/observatorium/api:latest"


### PR DESCRIPTION
Backport Loki operand update to `v3.1.0` into `release-5.8`

Refs: [LOG-5761](https://issues.redhat.com//browse/LOG-5761)

/cc @xperimental @JoaoBraveCoding
