### PR TITLE
[release-5.6] Backport PR grafana/loki#13422

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.21
 
+- [13422](https://github.com/grafana/loki/pull/13422) **periklis** feat(operator): Update Loki operand to v3.1.0
 - [13369](https://github.com/grafana/loki/pull/13369) **jatinsu**: feat(operator): Add support for the volume API
 
 ## Release 5.6.20

--- a/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -1342,7 +1342,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_LOKI
-                  value: quay.io/openshift-logging/loki:v2.9.8
+                  value: quay.io/openshift-logging/loki:v3.1.0
                 - name: RELATED_IMAGE_GATEWAY
                   value: quay.io/observatorium/api:latest
                 - name: RELATED_IMAGE_OPA
@@ -1464,7 +1464,7 @@ spec:
   provider:
     name: Grafana.com
   relatedImages:
-  - image: quay.io/openshift-logging/loki:v2.9.8
+  - image: quay.io/openshift-logging/loki:v3.1.0
     name: loki
   - image: quay.io/observatorium/api:latest
     name: gateway

--- a/operator/config/overlays/development/manager_related_image_patch.yaml
+++ b/operator/config/overlays/development/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.9.8
+            value: docker.io/grafana/loki:3.1.0
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/config/overlays/openshift/manager_related_image_patch.yaml
+++ b/operator/config/overlays/openshift/manager_related_image_patch.yaml
@@ -9,7 +9,7 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: quay.io/openshift-logging/loki:v2.9.8
+            value: quay.io/openshift-logging/loki:v3.1.0
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest
           - name: RELATED_IMAGE_OPA

--- a/operator/config/overlays/production/manager_related_image_patch.yaml
+++ b/operator/config/overlays/production/manager_related_image_patch.yaml
@@ -9,6 +9,6 @@ spec:
         - name: manager
           env:
           - name: RELATED_IMAGE_LOKI
-            value: docker.io/grafana/loki:2.9.8
+            value: docker.io/grafana/loki:3.1.0
           - name: RELATED_IMAGE_GATEWAY
             value: quay.io/observatorium/api:latest

--- a/operator/docs/operator/compatibility.md
+++ b/operator/docs/operator/compatibility.md
@@ -39,3 +39,4 @@ The versions of Loki compatible to be run with the Loki Operator are:
 * v2.9.4
 * v2.9.6
 * v2.9.8
+* v3.1.0

--- a/operator/hack/addons_dev.yaml
+++ b/operator/hack/addons_dev.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.9.8-amd64
+          image: docker.io/grafana/logcli:3.1.0-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -73,7 +73,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.9.8
+          image: docker.io/grafana/promtail:3.1.0
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/hack/addons_ocp.yaml
+++ b/operator/hack/addons_ocp.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: logcli
-          image: docker.io/grafana/logcli:2.9.8-amd64
+          image: docker.io/grafana/logcli:3.1.0-amd64
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
         - name: promtail
-          image: docker.io/grafana/promtail:2.9.8
+          image: docker.io/grafana/promtail:3.1.0
           args:
             - -config.file=/etc/promtail/promtail.yaml
             - -log.level=info

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -48,7 +48,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -63,7 +62,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -90,7 +88,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -165,7 +162,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -301,7 +297,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -316,7 +311,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -343,7 +337,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -418,7 +411,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -646,7 +638,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -661,7 +652,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -688,7 +678,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -817,7 +806,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -1000,7 +988,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -1015,7 +1002,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -1042,7 +1028,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -1171,7 +1156,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -1355,7 +1339,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -1370,7 +1353,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -1397,7 +1379,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -1539,7 +1520,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -1743,7 +1723,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -1758,7 +1737,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -1785,7 +1763,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -1865,7 +1842,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -2046,7 +2022,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -2061,7 +2036,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -2088,7 +2062,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -2243,7 +2216,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -2475,7 +2447,6 @@ frontend_worker:
     tls_server_name: query-frontend-grpc.svc
     tls_cipher_suites: cipher1,cipher2
     tls_min_version: VersionTLS12
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -2490,7 +2461,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -2524,7 +2494,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -2628,7 +2597,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
       grpc_client_config:
@@ -2804,7 +2772,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -2819,7 +2786,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -2846,7 +2812,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -2922,7 +2887,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:
@@ -3060,7 +3024,6 @@ frontend_worker:
   frontend_address: loki-query-frontend-grpc-lokistack-dev.default.svc.cluster.local:9095
   grpc_client_config:
     max_send_msg_size: 104857600
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -3076,7 +3039,6 @@ ingester:
     ring:
       replication_factor: 1
   max_chunk_age: 2h
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: /tmp/wal
@@ -3103,7 +3065,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -3179,7 +3140,6 @@ storage_config:
     cache_location: /tmp/loki/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: s3
     index_gateway_client:
       server_address: dns:///loki-index-gateway-grpc-lokistack-dev.default.svc.cluster.local:9095
 tracing:

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -94,7 +94,6 @@ frontend_worker:
     tls_cipher_suites: {{ .TLS.CipherSuitesString }}
     tls_min_version: {{ .TLS.MinTLSVersion }}
 {{- end }}
-  match_max_concurrent: true
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -112,7 +111,6 @@ ingester:
     {{- end}}
     ring:
       replication_factor: {{ .Stack.ReplicationFactor }}
-  max_transfer_retries: 0
   wal:
     enabled: true
     dir: {{ .WriteAheadLog.Directory }}
@@ -148,7 +146,6 @@ limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   creation_grace_period: 10m
-  enforce_metric_name: false
   # Keep max_streams_per_user always to 0 to default
   # using max_global_streams_per_user always.
   # (See https://github.com/grafana/loki/blob/main/pkg/ingester/limiter.go#L73)
@@ -451,7 +448,6 @@ storage_config:
     cache_location: {{ .StorageDirectory }}/index_cache
     cache_ttl: 24h
     resync_interval: 5m
-    shared_store: {{ .ObjectStorage.SharedStore }}
     index_gateway_client:
       server_address: dns:///{{ .IndexGateway.FQDN }}:{{ .IndexGateway.Port }}
 {{- if .Gates.GRPCEncryption }}

--- a/operator/internal/manifests/var.go
+++ b/operator/internal/manifests/var.go
@@ -57,7 +57,7 @@ const (
 	EnvRelatedImageGateway = "RELATED_IMAGE_GATEWAY"
 
 	// DefaultContainerImage declares the default fallback for loki image.
-	DefaultContainerImage = "docker.io/grafana/loki:2.9.8"
+	DefaultContainerImage = "docker.io/grafana/loki:3.1.0"
 
 	// DefaultLokiStackGatewayImage declares the default image for lokiStack-gateway.
 	DefaultLokiStackGatewayImage = "quay.io/observatorium/api:latest"


### PR DESCRIPTION
Backport Loki operand update to `v3.1.0` into `release-5.6`

Refs: [LOG-5761](https://issues.redhat.com//browse/LOG-5761)

/cc @xperimental @JoaoBraveCoding