### PR TITLE
[release-5.6] fix(operator): Disable structured metadata

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.21
 
+- [319](https://github.com/openshift/loki/pull/319) **periklis**: fix(operator): Disable structured metadata
 - [13422](https://github.com/grafana/loki/pull/13422) **periklis** feat(operator): Update Loki operand to v3.1.0
 - [13369](https://github.com/grafana/loki/pull/13369) **jatinsu**: feat(operator): Add support for the volume API
 

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -105,6 +105,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 1m
   volume_enabled: true
   volume_max_series: 1000
@@ -354,6 +355,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 1m
   volume_enabled: true
   volume_max_series: 1000
@@ -695,6 +697,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 1m
   volume_enabled: true
   volume_max_series: 1000
@@ -1045,6 +1048,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 1m
   volume_enabled: true
   volume_max_series: 1000
@@ -1396,6 +1400,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 1m
   volume_enabled: true
   volume_max_series: 1000
@@ -1785,6 +1790,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 1m
   volume_enabled: true
   volume_max_series: 1000
@@ -2079,6 +2085,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 2m
   volume_enabled: true
   volume_max_series: 1000
@@ -2511,6 +2518,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 1m
   volume_enabled: true
   volume_max_series: 1000
@@ -2829,6 +2837,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 1m
   volume_enabled: true
   volume_max_series: 1000
@@ -3082,6 +3091,7 @@ limits_config:
   per_stream_rate_limit: 3MB
   per_stream_rate_limit_burst: 15MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
   query_timeout: 1m
   volume_enabled: true
   volume_max_series: 1000

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -177,6 +177,7 @@ limits_config:
   per_stream_rate_limit: {{ .Stack.Limits.Global.IngestionLimits.PerStreamRateLimit }}MB
   per_stream_rate_limit_burst: {{ .Stack.Limits.Global.IngestionLimits.PerStreamRateLimitBurst }}MB
   split_queries_by_interval: 30m
+  allow_structured_metadata: false
 {{- with .GossipRing }}
 memberlist:
   abort_if_cluster_join_fails: true


### PR DESCRIPTION
Follow-up fix to set `allow_stuctured_metadata: false` for `release-5.8` missing support for object storage schema version `v13`. The wrong default `allow_structured_metadata: true` was introduced accidentaly with the last Loki update from `v2.9.8` to `v3.1.0` by:
- openshift/loki/pull/317

Ref: LOG-5761, [LOG-5778](https://issues.redhat.com//browse/LOG-5778)