### PR TITLE
[release-5.6] Backport PR grafana/loki#8579

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.21
 
+- [8579](https://github.com/grafana/loki/pull/8579) **periklis**: operator: Remove deprecated field querier.engine.timeout
 - [319](https://github.com/openshift/loki/pull/319) **periklis**: fix(operator): Disable structured metadata
 - [13422](https://github.com/grafana/loki/pull/13422) **periklis** feat(operator): Update Loki operand to v3.1.0
 - [13369](https://github.com/grafana/loki/pull/13369) **jatinsu**: feat(operator): Add support for the volume API

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -121,7 +121,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h
@@ -371,7 +370,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h
@@ -713,7 +711,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h
@@ -1064,7 +1061,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h
@@ -1416,7 +1412,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h
@@ -1806,7 +1801,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h
@@ -2101,7 +2095,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h
@@ -2534,7 +2527,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h
@@ -2854,7 +2846,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h
@@ -3108,7 +3099,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   max_concurrent: 2
   query_ingesters_within: 3h

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -195,7 +195,6 @@ memberlist:
 querier:
   engine:
     max_look_back_period: 30s
-    timeout: 3m
   extra_query_delay: 0s
   query_ingesters_within: 3h
   tail_max_duration: 1h


### PR DESCRIPTION
Backport missing PR that removes the deprecated field `querier.engine.timeout` in favor of the `limits_config.query_timeout` into `release-5.6`.

Refs: LOG-5761, [LOG-5778](https://issues.redhat.com//browse/LOG-5778)