### PR TITLE
[release-5.9] Backport PR for grafana/loki#13562

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.9.4
 
+- [13562](https://github.com/grafana/loki/pull/13562) **xperimental**: fix(operator): Set object storage for delete requests when using retention
 - [13463](https://github.com/grafana/loki/pull/13463) **periklis**: fix(operator): Allow structured metadata only if V13 schema provided
 - [13450](https://github.com/grafana/loki/pull/13450) **periklis**: fix(operator): Skip updating annotations for serviceaccounts
 - [13430](https://github.com/grafana/loki/pull/13430) **periklis**: fix(operator): Support v3.1.0 in OpenShift dashboards

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -1833,6 +1833,7 @@ compactor:
   retention_enabled: true
   retention_delete_delay: 4h
   retention_delete_worker_count: 50
+  delete_request_store: s3
 frontend:
   tail_proxy_url: http://loki-querier-http-lokistack-dev.default.svc.cluster.local:3100
   compress_responses: true

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -99,11 +99,14 @@ common:
 compactor:
   compaction_interval: 2h
   working_directory: {{ .StorageDirectory }}/compactor
-{{- if .Retention.Enabled }}{{- with .Retention }}
+{{- if .Retention.Enabled }}
+{{- with .Retention }}
   retention_enabled: true
   retention_delete_delay: 4h
   retention_delete_worker_count: {{.DeleteWorkerCount}}
-{{- end }}{{- end }}
+{{- end }}
+  delete_request_store: {{.ObjectStorage.SharedStore}}
+{{- end }}
 frontend:
   tail_proxy_url: {{ .Querier.Protocol }}://{{ .Querier.FQDN }}:{{ .Querier.Port }}
 {{- if .Gates.HTTPEncryption }}


### PR DESCRIPTION
Backport setting object storage for delete requests when using retention into `release-5.9`.

Ref: LOG-5761