### PR TITLE
[release-5.8] Backport PR for grafana/loki#13562

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Main
 
+## Release 5.8.10
+
+- [13562](https://github.com/grafana/loki/pull/13562) **xperimental**: fix(operator): Set object storage for delete requests when using retention
+
 ## Release 5.8.9
 
 - [13450](https://github.com/grafana/loki/pull/13450) **periklis**: fix(operator): Skip updating annotations for serviceaccounts

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -1741,6 +1741,7 @@ compactor:
   retention_enabled: true
   retention_delete_delay: 4h
   retention_delete_worker_count: 50
+  delete_request_store: s3
 frontend:
   tail_proxy_url: http://loki-querier-http-lokistack-dev.default.svc.cluster.local:3100
   compress_responses: true

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -89,11 +89,14 @@ common:
 compactor:
   compaction_interval: 2h
   working_directory: {{ .StorageDirectory }}/compactor
-{{- if .Retention.Enabled }}{{- with .Retention }}
+{{- if .Retention.Enabled }}
+{{- with .Retention }}
   retention_enabled: true
   retention_delete_delay: 4h
   retention_delete_worker_count: {{.DeleteWorkerCount}}
-{{- end }}{{- end }}
+{{- end }}
+  delete_request_store: {{.ObjectStorage.SharedStore}}
+{{- end }}
 frontend:
   tail_proxy_url: {{ .Querier.Protocol }}://{{ .Querier.FQDN }}:{{ .Querier.Port }}
 {{- if .Gates.HTTPEncryption }}


### PR DESCRIPTION
Backport setting object storage for delete requests when using retention into `release-5.8`.

Ref: [LOG-5821](https://issues.redhat.com//browse/LOG-5821)