### PR TITLE
[release-5.6] Backport PR for grafana/loki#13562

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.21
 
+- [13562](https://github.com/grafana/loki/pull/13562) **xperimental**: fix(operator): Set object storage for delete requests when using retention
 - [8579](https://github.com/grafana/loki/pull/8579) **periklis**: operator: Remove deprecated field querier.engine.timeout
 - [319](https://github.com/openshift/loki/pull/319) **periklis**: fix(operator): Disable structured metadata
 - [13422](https://github.com/grafana/loki/pull/13422) **periklis** feat(operator): Update Loki operand to v3.1.0

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -1714,6 +1714,7 @@ compactor:
   retention_enabled: true
   retention_delete_delay: 4h
   retention_delete_worker_count: 50
+  delete_request_store: s3
 frontend:
   tail_proxy_url: http://loki-querier-http-lokistack-dev.default.svc.cluster.local:3100
   compress_responses: true

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -62,11 +62,14 @@ common:
 compactor:
   compaction_interval: 2h
   working_directory: {{ .StorageDirectory }}/compactor
-{{- if .Retention.Enabled }}{{- with .Retention }}
+{{- if .Retention.Enabled }}
+{{- with .Retention }}
   retention_enabled: true
   retention_delete_delay: 4h
   retention_delete_worker_count: {{.DeleteWorkerCount}}
-{{- end }}{{- end }}
+{{- end }}
+  delete_request_store: {{.ObjectStorage.SharedStore}}
+{{- end }}
 frontend:
   tail_proxy_url: {{ .Querier.Protocol }}://{{ .Querier.FQDN }}:{{ .Querier.Port }}
 {{- if .Gates.HTTPEncryption }}


### PR DESCRIPTION
Backport setting object storage for delete requests when using retention into `release-5.6`.

Ref: [LOG-5761](https://issues.redhat.com//browse/LOG-5761)