### PR TITLE
[release-5.9] Backport PR grafana/loki#13708

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.9.5
 
+- [13708](https://github.com/grafana/loki/pull/13708) **periklis**: fix(operator): Don't overwrite annotations for LokiStack ingress resources
 - [13512](https://github.com/grafana/loki/pull/13512) **xperimental**: feat(operator): Add alert for discarded samples
 - [13497](https://github.com/grafana/loki/pull/13497) **xperimental**: fix(operator): Remove duplicate conditions from status
 

--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -206,14 +206,12 @@ func mutateServiceMonitor(existing, desired *monitoringv1.ServiceMonitor) {
 
 func mutateIngress(existing, desired *networkingv1.Ingress) {
 	existing.Labels = desired.Labels
-	existing.Annotations = desired.Annotations
 	existing.Spec.DefaultBackend = desired.Spec.DefaultBackend
 	existing.Spec.Rules = desired.Spec.Rules
 	existing.Spec.TLS = desired.Spec.TLS
 }
 
 func mutateRoute(existing, desired *routev1.Route) {
-	existing.Annotations = desired.Annotations
 	existing.Labels = desired.Labels
 	existing.Spec = desired.Spec
 }


### PR DESCRIPTION
Backport ingress annotation handling in `release-5.9`.

Refs: [LOG-5945](https://issues.redhat.com//browse/LOG-5945)