### PR TITLE
[release-5.8] Backport PR grafana/loki#13708

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.8.11
 
+- [13708](https://github.com/grafana/loki/pull/13708) **periklis**: fix(operator): Don't overwrite annotations for LokiStack ingress resources
 - **xperimental**: Backport status handling in controller
 - [12212](https://github.com/grafana/loki/pull/12212) **xperimental**: Do not overwrite complete status when updating schemas
 - [12228](https://github.com/grafana/loki/pull/12228) **xperimental**: Restructure LokiStack metrics

--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -200,14 +200,12 @@ func mutateServiceMonitor(existing, desired *monitoringv1.ServiceMonitor) {
 
 func mutateIngress(existing, desired *networkingv1.Ingress) {
 	existing.Labels = desired.Labels
-	existing.Annotations = desired.Annotations
 	existing.Spec.DefaultBackend = desired.Spec.DefaultBackend
 	existing.Spec.Rules = desired.Spec.Rules
 	existing.Spec.TLS = desired.Spec.TLS
 }
 
 func mutateRoute(existing, desired *routev1.Route) {
-	existing.Annotations = desired.Annotations
 	existing.Labels = desired.Labels
 	existing.Spec = desired.Spec
 }


### PR DESCRIPTION
Backport ingress annotation handling in `release-5.8`.

Refs: [LOG-5946](https://issues.redhat.com//browse/LOG-5946)