### PR TITLE
[release-5.6] Backport PR grafana/loki#13708

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 5.6.22
 
+- [13708](https://github.com/grafana/loki/pull/13708) **periklis**: fix(operator): Don't overwrite annotations for LokiStack ingress resources
 - [openshift#338](https://github.com/openshift/loki/pull/338) **xperimental**: Remove unused telemetry metrics
 - [13512](https://github.com/grafana/loki/pull/13512) **xperimental**: feat(operator): Add alert for discarded samples
 

--- a/operator/internal/manifests/mutate.go
+++ b/operator/internal/manifests/mutate.go
@@ -186,14 +186,12 @@ func mutateServiceMonitor(existing, desired *monitoringv1.ServiceMonitor) {
 
 func mutateIngress(existing, desired *networkingv1.Ingress) {
 	existing.Labels = desired.Labels
-	existing.Annotations = desired.Annotations
 	existing.Spec.DefaultBackend = desired.Spec.DefaultBackend
 	existing.Spec.Rules = desired.Spec.Rules
 	existing.Spec.TLS = desired.Spec.TLS
 }
 
 func mutateRoute(existing, desired *routev1.Route) {
-	existing.Annotations = desired.Annotations
 	existing.Labels = desired.Labels
 	existing.Spec = desired.Spec
 }


### PR DESCRIPTION
Backport ingress annotation handling in `release-5.6`.

Refs: [LOG-5947](https://issues.redhat.com//browse/LOG-5947)