### PR TITLE
[release-6.0] Backport PR grafana/loki#14314

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 6.0.1
 
+- [14314](https://github.com/grafana/loki/pull/14314) **periklis**: fix(operator): Use empty initiliazed pod status map when no pods
 - [14308](https://github.com/grafana/loki/pull/14308) **periklis**: feat(operator): Declare feature FIPS support for OpenShift only
 - [14279](https://github.com/grafana/loki/pull/14279) **periklis**: fix(operator): Add missing groupBy label for all rules on OpenShift
 

--- a/operator/internal/status/components.go
+++ b/operator/internal/status/components.go
@@ -73,6 +73,15 @@ func appendPodStatus(ctx context.Context, k k8s.Client, component, stack, ns str
 		status := podStatus(&pod)
 		psm[status] = append(psm[status], pod.Name)
 	}
+
+	if len(psm) == 0 {
+		psm = lokiv1.PodStatusMap{
+			lokiv1.PodFailed:  []string{},
+			lokiv1.PodPending: []string{},
+			lokiv1.PodRunning: []string{},
+			lokiv1.PodReady:   []string{},
+		}
+	}
 	return psm, nil
 }
 

--- a/operator/internal/status/components_test.go
+++ b/operator/internal/status/components_test.go
@@ -65,6 +65,13 @@ func setupListClient(t *testing.T, stack *lokiv1.LokiStack, componentPods map[st
 }
 
 func TestGenerateComponentStatus(t *testing.T) {
+	empty := lokiv1.PodStatusMap{
+		lokiv1.PodFailed:  []string{},
+		lokiv1.PodPending: []string{},
+		lokiv1.PodRunning: []string{},
+		lokiv1.PodReady:   []string{},
+	}
+
 	tt := []struct {
 		desc                string
 		componentPods       map[string]*corev1.PodList
@@ -83,14 +90,14 @@ func TestGenerateComponentStatus(t *testing.T) {
 				manifests.LabelGatewayComponent:       {},
 			},
 			wantComponentStatus: &lokiv1.LokiStackComponentStatus{
-				Compactor:     lokiv1.PodStatusMap{},
-				Distributor:   lokiv1.PodStatusMap{},
-				IndexGateway:  lokiv1.PodStatusMap{},
-				Ingester:      lokiv1.PodStatusMap{},
-				Querier:       lokiv1.PodStatusMap{},
-				QueryFrontend: lokiv1.PodStatusMap{},
-				Gateway:       lokiv1.PodStatusMap{},
-				Ruler:         lokiv1.PodStatusMap{},
+				Compactor:     empty,
+				Distributor:   empty,
+				IndexGateway:  empty,
+				Ingester:      empty,
+				Querier:       empty,
+				QueryFrontend: empty,
+				Gateway:       empty,
+				Ruler:         empty,
 			},
 		},
 		{
@@ -114,6 +121,29 @@ func TestGenerateComponentStatus(t *testing.T) {
 				QueryFrontend: lokiv1.PodStatusMap{lokiv1.PodRunning: {"query-frontend-pod-0"}},
 				Gateway:       lokiv1.PodStatusMap{lokiv1.PodRunning: {"lokistack-gateway-pod-0"}},
 				Ruler:         lokiv1.PodStatusMap{lokiv1.PodRunning: {"ruler-pod-0"}},
+			},
+		},
+		{
+			desc: "all pods without ruler",
+			componentPods: map[string]*corev1.PodList{
+				manifests.LabelCompactorComponent:     createPodList(manifests.LabelCompactorComponent, false, corev1.PodRunning),
+				manifests.LabelDistributorComponent:   createPodList(manifests.LabelDistributorComponent, false, corev1.PodRunning),
+				manifests.LabelIngesterComponent:      createPodList(manifests.LabelIngesterComponent, false, corev1.PodRunning),
+				manifests.LabelQuerierComponent:       createPodList(manifests.LabelQuerierComponent, false, corev1.PodRunning),
+				manifests.LabelQueryFrontendComponent: createPodList(manifests.LabelQueryFrontendComponent, false, corev1.PodRunning),
+				manifests.LabelIndexGatewayComponent:  createPodList(manifests.LabelIndexGatewayComponent, false, corev1.PodRunning),
+				manifests.LabelRulerComponent:         {},
+				manifests.LabelGatewayComponent:       createPodList(manifests.LabelGatewayComponent, false, corev1.PodRunning),
+			},
+			wantComponentStatus: &lokiv1.LokiStackComponentStatus{
+				Compactor:     lokiv1.PodStatusMap{lokiv1.PodRunning: {"compactor-pod-0"}},
+				Distributor:   lokiv1.PodStatusMap{lokiv1.PodRunning: {"distributor-pod-0"}},
+				IndexGateway:  lokiv1.PodStatusMap{lokiv1.PodRunning: {"index-gateway-pod-0"}},
+				Ingester:      lokiv1.PodStatusMap{lokiv1.PodRunning: {"ingester-pod-0"}},
+				Querier:       lokiv1.PodStatusMap{lokiv1.PodRunning: {"querier-pod-0"}},
+				QueryFrontend: lokiv1.PodStatusMap{lokiv1.PodRunning: {"query-frontend-pod-0"}},
+				Gateway:       lokiv1.PodStatusMap{lokiv1.PodRunning: {"lokistack-gateway-pod-0"}},
+				Ruler:         empty,
 			},
 		},
 	}


### PR DESCRIPTION
Backport component view initialization in OCP console when no pods in to `release-6.0`.

Refs: [LOG-6129](https://issues.redhat.com//browse/LOG-6129)

/cc @xperimental @JoaoBraveCoding 