### PR TITLE
LOG-6256: Disable automatic discovery of service name

### DIFF
--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -95,6 +95,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -346,6 +347,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -705,6 +707,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1057,6 +1060,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1410,6 +1414,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1797,6 +1802,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2122,6 +2128,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2556,6 +2563,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2875,6 +2883,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3366,6 +3375,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3621,6 +3631,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3877,6 +3888,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4134,6 +4146,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4423,6 +4436,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -182,6 +182,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
   max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
+  discover_service_name: []
   max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerTenant }}
   max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
   max_query_length: 721h


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of grafana/loki#14506 to `release-5.8`.
