### PR TITLE
LOG-6295: Disable automatic discovery of service name

### DIFF
--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -96,6 +96,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -353,6 +354,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -779,6 +781,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1137,6 +1140,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1496,6 +1500,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1889,6 +1894,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2224,6 +2230,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2664,6 +2671,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2989,6 +2997,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3486,6 +3495,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3747,6 +3757,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4009,6 +4020,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4272,6 +4284,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4571,6 +4584,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4868,6 +4882,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5366,6 +5381,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5542,6 +5558,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: 256000
   max_entries_limit_per_query: 5000
+  discover_service_name: []
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -192,6 +192,7 @@ limits_config:
   max_streams_per_user: 0
   max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
   max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
+  discover_service_name: []
   max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerTenant }}
   max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
   max_query_length: 721h


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of grafana/loki#14506 to `release-5.9`.
