### PR TITLE
LOG-6321: Disable log level discovery for OpenShift tenancy modes

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Release 5.9.9
 
+- [14613](https://github.com/grafana/loki/pull/14613) **xperimental**: fix(operator): Disable log level discovery for OpenShift tenancy modes
+- [14506](https://github.com/grafana/loki/pull/14506) **xperimental**: fix(operator): Disable automatic discovery of service name
 - [14587](https://github.com/grafana/loki/pull/14587) **JoaoBraveCoding**: fix(operator): correctly ignore again BlotDB dashboards
 - [14447](https://github.com/grafana/loki/pull/14447) **periklis**: refactor(operator)!: Migrate project layout to kubebuilder go/v4
 - [14526](https://github.com/grafana/loki/pull/14526) **periklis**: feat(operator): Update Loki operand to v3.2.1

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -194,6 +194,7 @@ func ConfigOptions(opt Options) config.Options {
 		ObjectStorage:         opt.ObjectStorage,
 		HTTPTimeouts:          opt.Timeouts.Loki,
 		EnableRemoteReporting: opt.Gates.GrafanaLabsUsageReport,
+		DiscoverLogLevels:     discoverLogLevels(&opt.Stack),
 		Ruler: config.Ruler{
 			Enabled:               rulerEnabled,
 			RulesStorageDirectory: rulesStorageDirectory,
@@ -393,4 +394,17 @@ func retentionConfig(ls *lokiv1.LokiStackSpec) config.RetentionOptions {
 		Enabled:           true,
 		DeleteWorkerCount: deleteWorkerCountMap[ls.Size],
 	}
+}
+
+func discoverLogLevels(ls *lokiv1.LokiStackSpec) bool {
+	if ls.Tenants == nil {
+		return true
+	}
+
+	if ls.Tenants.Mode == lokiv1.OpenshiftLogging ||
+		ls.Tenants.Mode == lokiv1.OpenshiftNetwork {
+		return false
+	}
+
+	return true
 }

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -97,6 +97,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: true
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -259,6 +260,7 @@ overrides:
 		},
 		Shippers:              []string{"boltdb"},
 		EnableRemoteReporting: true,
+		DiscoverLogLevels:     true,
 		HTTPTimeouts: HTTPTimeoutConfig{
 			IdleTimeout:  30 * time.Second,
 			ReadTimeout:  30 * time.Second,
@@ -355,6 +357,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -782,6 +785,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1141,6 +1145,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1501,6 +1506,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1895,6 +1901,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2231,6 +2238,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2672,6 +2680,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2998,6 +3007,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3496,6 +3506,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3758,6 +3769,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4021,6 +4033,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4285,6 +4298,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4585,6 +4599,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4883,6 +4898,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5382,6 +5398,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -5559,6 +5576,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -193,6 +193,7 @@ limits_config:
   max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
   max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
   discover_service_name: []
+  discover_log_levels: {{ .DiscoverLogLevels }}
   max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerTenant }}
   max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
   max_query_length: 721h

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	MaxConcurrent         MaxConcurrent
 	WriteAheadLog         WriteAheadLog
 	EnableRemoteReporting bool
+	DiscoverLogLevels     bool
 	Shippers              []string
 
 	ObjectStorage storage.Options


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of grafana/loki#14613 to `release-5.9`