### PR TITLE
LOG-6322: Disable log level discovery for OpenShift tenancy modes

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## Main
 
-## Release 5.8.16
-
-- [14587](https://github.com/grafana/loki/pull/14587) **JoaoBraveCoding**: fix(operator): correctly ignore again BlotDB dashboards
-
 ## Release 5.8.15
 
+- [14613](https://github.com/grafana/loki/pull/14613) **xperimental**: fix(operator): Disable log level discovery for OpenShift tenancy modes
+- [14506](https://github.com/grafana/loki/pull/14506) **xperimental**: fix(operator): Disable automatic discovery of service name
+- [14587](https://github.com/grafana/loki/pull/14587) **JoaoBraveCoding**: fix(operator): correctly ignore again BlotDB dashboards
 - [14526](https://github.com/grafana/loki/pull/14526) **periklis**: feat(operator): Update Loki operand to v3.2.1
 - [14568](https://github.com/grafana/loki/pull/14568) **periklis**: refactor(operator)!: Rename loki api go module
 - [14447](https://github.com/grafana/loki/pull/14447) **periklis**: refactor(operator)!: Migrate project layout to kubebuilder go/v4

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -178,6 +178,7 @@ func ConfigOptions(opt Options) config.Options {
 		ObjectStorage:         opt.ObjectStorage,
 		HTTPTimeouts:          opt.Timeouts.Loki,
 		EnableRemoteReporting: opt.Gates.GrafanaLabsUsageReport,
+		DiscoverLogLevels:     discoverLogLevels(&opt.Stack),
 		Ruler: config.Ruler{
 			Enabled:               rulerEnabled,
 			RulesStorageDirectory: rulesStorageDirectory,
@@ -377,4 +378,17 @@ func retentionConfig(ls *lokiv1.LokiStackSpec) config.RetentionOptions {
 		Enabled:           true,
 		DeleteWorkerCount: deleteWorkerCountMap[ls.Size],
 	}
+}
+
+func discoverLogLevels(ls *lokiv1.LokiStackSpec) bool {
+	if ls.Tenants == nil {
+		return true
+	}
+
+	if ls.Tenants.Mode == lokiv1.OpenshiftLogging ||
+		ls.Tenants.Mode == lokiv1.OpenshiftNetwork {
+		return false
+	}
+
+	return true
 }

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -96,6 +96,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: true
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -252,6 +253,7 @@ overrides:
 			},
 		},
 		EnableRemoteReporting: true,
+		DiscoverLogLevels:     true,
 		HTTPTimeouts: HTTPTimeoutConfig{
 			IdleTimeout:  30 * time.Second,
 			ReadTimeout:  30 * time.Second,
@@ -348,6 +350,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -708,6 +711,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1061,6 +1065,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1415,6 +1420,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -1803,6 +1809,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2129,6 +2136,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2564,6 +2572,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -2884,6 +2893,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3376,6 +3386,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3632,6 +3643,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -3889,6 +3901,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4147,6 +4160,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h
@@ -4437,6 +4451,7 @@ limits_config:
   max_line_size: 256000
   max_entries_limit_per_query: 5000
   discover_service_name: []
+  discover_log_levels: false
   max_global_streams_per_user: 0
   max_chunks_per_query: 2000000
   max_query_length: 721h

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -183,6 +183,7 @@ limits_config:
   max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
   max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
   discover_service_name: []
+  discover_log_levels: {{ .DiscoverLogLevels }}
   max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerTenant }}
   max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
   max_query_length: 721h

--- a/operator/internal/manifests/internal/config/options.go
+++ b/operator/internal/manifests/internal/config/options.go
@@ -29,6 +29,7 @@ type Options struct {
 	MaxConcurrent         MaxConcurrent
 	WriteAheadLog         WriteAheadLog
 	EnableRemoteReporting bool
+	DiscoverLogLevels     bool
 
 	ObjectStorage storage.Options
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of grafana/loki#14613 to `release-5.8`
