### PR TITLE
LOG-6347: Update maximum OpenShift version to match supported range

### DIFF
--- a/operator/bundle/openshift/metadata/properties.yaml
+++ b/operator/bundle/openshift/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.17
+    value: 4.16


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the maximum OpenShift version to match the supported versions range.

**Which issue(s) this PR fixes**:

[LOG-6347](https://issues.redhat.com//browse/LOG-6347)
