### PR TITLE
[release-6.1] Backport PR grafana/loki#14752

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,7 +1,16 @@
 ## Main
 
-## [0.7.0](https://github.com/grafana/loki/compare/operator/v0.6.2...operator/v0.7.0) (2024-11-01)
+## Release 6.1.1
 
+- [14752](https://github.com/grafana/loki/pull/14752) **periklis**: Add support for managed GCP WorkloadIdentity
+
+## Release 6.1.0
+
+- [14407](https://github.com/grafana/loki/issues/14407) **JoaoBraveCoding**: Introduce 1x.pico size
+- [14410](https://github.com/grafana/loki/issues/14410) **xperimental**: Provide default OTLP attribute configuration
+- [14526](https://github.com/grafana/loki/issues/14526) **periklis**: Update Loki operand to v3.2.1
+
+## [0.7.0](https://github.com/grafana/loki/compare/operator/v0.6.2...operator/v0.7.0) (2024-11-01)
 
 ### ⚠ BREAKING CHANGES
 

--- a/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/community-openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -159,7 +159,7 @@ metadata:
     features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
-    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/token-auth-gcp: "true"
     operators.operatorframework.io/builder: operator-sdk-unknown
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/grafana/loki/tree/main/operator

--- a/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
+++ b/operator/bundle/openshift/manifests/loki-operator.clusterserviceversion.yaml
@@ -166,7 +166,7 @@ metadata:
     features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
-    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/token-auth-gcp: "true"
     olm.skipRange: '>=5.9.0-0 <6.1.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat

--- a/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/community-openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
     features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
-    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/token-auth-gcp: "true"
     repository: https://github.com/grafana/loki/tree/main/operator
     support: Grafana Loki SIG Operator
   labels:

--- a/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/openshift/bases/loki-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
     features.operators.openshift.io/tls-profiles: "true"
     features.operators.openshift.io/token-auth-aws: "true"
     features.operators.openshift.io/token-auth-azure: "true"
-    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/token-auth-gcp: "true"
     olm.skipRange: '>=5.9.0-0 <6.1.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-operators-redhat

--- a/operator/internal/manifests/openshift/credentialsrequest.go
+++ b/operator/internal/manifests/openshift/credentialsrequest.go
@@ -98,6 +98,15 @@ func encodeProviderSpec(env *config.TokenCCOAuthConfig) (*runtime.RawExtension, 
 			AzureSubscriptionID: azure.SubscriptionID,
 			AzureTenantID:       azure.TenantID,
 		}
+	case env.GCP != nil:
+		spec = &cloudcredentialv1.GCPProviderSpec{
+			PredefinedRoles: []string{
+				"roles/iam.workloadIdentityUser",
+				"roles/storage.objectAdmin",
+			},
+			Audience:            env.GCP.Audience,
+			ServiceAccountEmail: env.GCP.ServiceAccountEmail,
+		}
 	}
 
 	encodedSpec, err := cloudcredentialv1.Codec.EncodeProviderSpec(spec.DeepCopyObject())

--- a/operator/internal/manifests/storage/configure_test.go
+++ b/operator/internal/manifests/storage/configure_test.go
@@ -690,6 +690,103 @@ func TestConfigureDeploymentForStorageType(t *testing.T) {
 			},
 		},
 		{
+			desc: "object storage GCS with Workload Identity and OpenShift Managed Credentials",
+			opts: Options{
+				SecretName:     "test",
+				SharedStore:    lokiv1.ObjectStorageSecretGCS,
+				CredentialMode: lokiv1.CredentialModeTokenCCO,
+				GCS: &GCSStorageConfig{
+					WorkloadIdentity: true,
+				},
+				OpenShift: OpenShiftOptions{
+					Enabled: true,
+					CloudCredentials: CloudCredentials{
+						SecretName: "cloud-credentials",
+						SHA1:       "deadbeef",
+					},
+				},
+			},
+			dpl: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "loki-ingester",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "test",
+											ReadOnly:  false,
+											MountPath: "/etc/storage/secrets",
+										},
+										{
+											Name:      saTokenVolumeName,
+											ReadOnly:  false,
+											MountPath: saTokenVolumeMountPath,
+										},
+										tokenCCOAuthConfigVolumeMount,
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name:  EnvGoogleApplicationCredentials,
+											Value: "/etc/storage/token-auth/service_account.json",
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "test",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "test",
+										},
+									},
+								},
+								{
+									Name: saTokenVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										Projected: &corev1.ProjectedVolumeSource{
+											Sources: []corev1.VolumeProjection{
+												{
+													ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+														Audience:          gcpDefaultAudience,
+														ExpirationSeconds: ptr.To[int64](3600),
+														Path:              corev1.ServiceAccountTokenKey,
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: tokenAuthConfigVolumeName,
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "cloud-credentials",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "object storage S3",
 			opts: Options{
 				SecretName:  "test",

--- a/operator/internal/manifests/storage/var.go
+++ b/operator/internal/manifests/storage/var.go
@@ -97,6 +97,8 @@ const (
 	KeyGCPStorageBucketName = "bucketname"
 	// KeyGCPServiceAccountKeyFilename is the service account key filename containing the Google authentication credentials.
 	KeyGCPServiceAccountKeyFilename = "key.json"
+	// KeyGCPManagedServiceAccountKeyFilename is the service account key filename for the managed Google service account.
+	KeyGCPManagedServiceAccountKeyFilename = "service_account.json"
 
 	// KeySwiftAuthURL is the secret data key for the OpenStack Swift authentication URL.
 	KeySwiftAuthURL = "auth_url"
@@ -140,9 +142,9 @@ const (
 	tokenAuthConfigVolumeName = "token-auth-config"
 	tokenAuthConfigDirectory  = "/etc/storage/token-auth"
 
-	awsDefaultAudience = "sts.amazonaws.com"
-
+	awsDefaultAudience   = "sts.amazonaws.com"
 	azureDefaultAudience = "api://AzureADTokenExchange"
+	gcpDefaultAudience   = "openshift"
 
 	azureManagedCredentialKeyClientID       = "azure_client_id"
 	azureManagedCredentialKeyTenantID       = "azure_tenant_id"


### PR DESCRIPTION
Add support for managed GCP WorkloadIdentity to `release-6.1`.

Refs: [LOG-6158](https://issues.redhat.com//browse/LOG-6158)