### PR TITLE
LOG-6375: Update maximum OpenShift version to match supported range

### DIFF
--- a/operator/bundle/metadata/properties.yaml
+++ b/operator/bundle/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.14
+    value: 4.13


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the maximum OpenShift version the operator is installable on to match the last version of OpenShift we officially [support](https://access.redhat.com/support/policy/updates/openshift_operators) for it.

**Which issue(s) this PR fixes**:

LOG-6375
