### PR TITLE
LOG-6693: Fix minimum available ingesters for 1x.pico size

### DIFF
--- a/operator/internal/manifests/internal/sizes.go
+++ b/operator/internal/manifests/internal/sizes.go
@@ -68,7 +68,7 @@ var ResourceRequirementsTable = map[lokiv1.LokiStackSizeType]ComponentResources{
 				corev1.ResourceCPU:    resource.MustParse("500m"),
 				corev1.ResourceMemory: resource.MustParse("3Gi"),
 			},
-			PDBMinAvailable: 1,
+			PDBMinAvailable: 2,
 		},
 		Distributor: corev1.ResourceRequirements{
 			Requests: map[corev1.ResourceName]resource.Quantity{


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of grafana/loki#16035 to `release-6.1`.

/cc @JoaoBraveCoding 