### PR TITLE
LOG-6534: Revert change due to changed release plans

### DIFF
--- a/operator/bundle/openshift/metadata/properties.yaml
+++ b/operator/bundle/openshift/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.17
+    value: 4.16


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts the change introduced in #405 , because we pushed the change out to the next release.

**Which issue(s) this PR fixes**:

Refs [LOG-6534](https://issues.redhat.com//browse/LOG-6534)
