### PR TITLE
LOG-6797: Select non-zero delete worker count for all sizes

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Release 6.1.4
 
+- [16492](https://github.com/grafana/loki/pull/16492) **xperimental**: Select non-zero delete worker count for all sizes
 - [16360](https://github.com/grafana/loki/pull/16360) **xperimental**: Update Loki operator to v3.4.2
 
 ## Release 6.1.2

--- a/operator/internal/manifests/config.go
+++ b/operator/internal/manifests/config.go
@@ -367,11 +367,13 @@ func remoteWriteConfig(s *lokiv1.RemoteWriteSpec, rs *RulerSecret) *config.Remot
 	return c
 }
 
-var deleteWorkerCountMap = map[lokiv1.LokiStackSizeType]uint{
-	lokiv1.SizeOneXDemo:       10,
-	lokiv1.SizeOneXExtraSmall: 10,
-	lokiv1.SizeOneXSmall:      150,
-	lokiv1.SizeOneXMedium:     150,
+func deleteWorkerCount(size lokiv1.LokiStackSizeType) uint {
+	switch size {
+	case lokiv1.SizeOneXSmall, lokiv1.SizeOneXMedium:
+		return 150
+	default:
+		return 10
+	}
 }
 
 func retentionConfig(ls *lokiv1.LokiStackSpec) config.RetentionOptions {
@@ -394,7 +396,7 @@ func retentionConfig(ls *lokiv1.LokiStackSpec) config.RetentionOptions {
 
 	return config.RetentionOptions{
 		Enabled:           true,
-		DeleteWorkerCount: deleteWorkerCountMap[ls.Size],
+		DeleteWorkerCount: deleteWorkerCount(ls.Size),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the Operator code, so that the delete worker count can never be zero. This happened for the `1x.pico` size introduced in Loki Operator 6.1

**Which issue(s) this PR fixes**:

Fixes [LOG-6797](https://issues.redhat.com//browse/LOG-6797)

/cc @JoaoBraveCoding 
/hold wait for next z-stream