### PR TITLE
LOG-6534: Reapply change to maximum OpenShift version

### DIFF
--- a/operator/bundle/openshift/metadata/properties.yaml
+++ b/operator/bundle/openshift/metadata/properties.yaml
@@ -1,3 +1,3 @@
 properties:
   - type: olm.maxOpenShiftVersion
-    value: 4.16
+    value: 4.17


### PR DESCRIPTION
**What this PR does / why we need it**:

This reapplies the change introduced in #405 which was reverted in #412.

**Which issue(s) this PR fixes**:

Fixes [LOG-6534](https://issues.redhat.com//browse/LOG-6534)
