### PR TITLE
LOG-6991: Enable time-based stream-sharding

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Main
 
+## Release 6.1.5
+
+- [16390](https://github.com/grafana/loki/pull/16390) **xperimental**: Enable time-based stream-sharding
+
 ## Release 6.1.4
 
 - [16492](https://github.com/grafana/loki/pull/16492) **xperimental**: Select non-zero delete worker count for all sizes

--- a/operator/internal/manifests/internal/config/build_test.go
+++ b/operator/internal/manifests/internal/config/build_test.go
@@ -116,6 +116,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -376,6 +377,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -804,6 +806,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -1164,6 +1167,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -1525,6 +1529,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -1925,6 +1930,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -2257,6 +2263,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -2698,6 +2705,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -3024,6 +3032,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -3523,6 +3532,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -3786,6 +3796,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -4050,6 +4061,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -4315,6 +4327,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -4616,6 +4629,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -5764,6 +5778,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: false
 memberlist:
   abort_if_cluster_join_fails: true
@@ -6156,6 +6171,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: 3MB
+    time_sharding_enabled: true
   allow_structured_metadata: true
   otlp_config:
     resource_attributes:

--- a/operator/internal/manifests/internal/config/loki-config.yaml
+++ b/operator/internal/manifests/internal/config/loki-config.yaml
@@ -229,6 +229,7 @@ limits_config:
   shard_streams:
     enabled: true
     desired_rate: {{ . }}MB
+    time_sharding_enabled: true
 {{- end }}
 {{- with .OTLPAttributes.Global }}
   otlp_config:


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables time-based sharding of streams in Loki.

**Which issue(s) this PR fixes**:

Fixes [LOG-6991](https://issues.redhat.com//browse/LOG-6991)

/cc @JoaoBraveCoding 