### PR TITLE
Update version information to 6.6

### DIFF
--- a/operator/Dockerfile.art
+++ b/operator/Dockerfile.art
@@ -29,5 +29,5 @@ LABEL com.redhat.component="loki-operator-container" \
       summary="OpenShift Loki Operator to manage LokiStack installs for Openshift Logging." \
       url="https://catalog.redhat.com/en/software/containers/openshift-logging/loki-rhel9-operator/64479927e1820602a81cdf13" \
       vendor="Red Hat, Inc." \
-      version_minor="v6.5" \
-      version="6.5.0"
+      version_minor="v6.6" \
+      version="6.6.0"

--- a/operator/bundle/art.yaml
+++ b/operator/bundle/art.yaml
@@ -6,6 +6,6 @@ updates:
   - search: "quay.io/openshift/origin-kube-rbac-proxy:latest"
     replace: "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:b30b0bcd2199e73ce519ed106ba4a923b2c5aadc8698816a53ea56b770caf683"
   - search: "0.1.0"
-    replace: "6.5.0"
+    replace: "6.6.0"
   - search: "olm.skipRange: '>=6.0.0-0 <6.2.0'"
-    replace: "olm.skipRange: '>=6.3.0-0 <6.5.0'"
+    replace: "olm.skipRange: '>=6.4.0-0 <6.6.0'"

--- a/operator/bundle/loki-operator.package.yaml
+++ b/operator/bundle/loki-operator.package.yaml
@@ -1,5 +1,5 @@
 ---
 packageName: loki-operator
 channels:
-- name: stable-6.5
-  currentCSV: loki-operator.v6.5.0
+- name: stable-6.6
+  currentCSV: loki-operator.v6.6.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates version information in `main` to be Logging 6.6

**Which issue(s) this PR fixes**:

[LOG-8966](https://redhat.atlassian.net/browse/LOG-8966)

/cc @JoaoBraveCoding 
/assign @xperimental 
/label tide/merge-method-squash