### PR TITLE
ingester/distributor: Ensure PDB is set to maxUnavailable of 1

### DIFF
--- a/operator/internal/manifests/distributor.go
+++ b/operator/internal/manifests/distributor.go
@@ -236,7 +236,7 @@ func configureDistributorGRPCServicePKI(deployment *appsv1.Deployment, opts Opti
 // Distributor pods.
 func newDistributorPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelDistributorComponent, opts.Name)
-	mu := intstr.FromInt(1)
+	maxUnavailable := intstr.FromInt32(1)
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -251,7 +251,7 @@ func newDistributorPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudg
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &mu,
+			MaxUnavailable: &maxUnavailable,
 		},
 	}
 }

--- a/operator/internal/manifests/ingester.go
+++ b/operator/internal/manifests/ingester.go
@@ -290,17 +290,7 @@ func configureIngesterGRPCServicePKI(sts *appsv1.StatefulSet, opts Options) erro
 // Ingester pods.
 func newIngesterPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget {
 	l := ComponentLabels(LabelIngesterComponent, opts.Name)
-	rf := DefaultLokiStackSpec(opts.Stack.Size).Replication.Factor
-	if opts.Stack.Replication != nil && opts.Stack.Replication.Factor != 0 {
-		rf = opts.Stack.Replication.Factor
-	}
-
-	pdbMinAvailable := rf
-	if pdbMinAvailable >= opts.Stack.Template.Ingester.Replicas {
-		pdbMinAvailable = max(1, opts.Stack.Template.Ingester.Replicas-1)
-	}
-	minAvailable := intstr.FromInt32(pdbMinAvailable)
-
+	maxUnavailable := intstr.FromInt32(1)
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -315,7 +305,7 @@ func newIngesterPodDisruptionBudget(opts Options) *policyv1.PodDisruptionBudget 
 			Selector: &metav1.LabelSelector{
 				MatchLabels: l,
 			},
-			MinAvailable: &minAvailable,
+			MaxUnavailable: &maxUnavailable,
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Special notes for your reviewer**:

**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/grafana/loki/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] Documentation added
- [ ] Tests updated
- [ ] Title matches the required conventional commits format, see [here](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes that require user attention or interaction to upgrade are documented in `docs/sources/setup/upgrade/_index.md`
- [ ] If the change is deprecating or removing a configuration option, update the `deprecated-config.yaml` and `deleted-config.yaml` files respectively in the `tools/deprecated-config-checker` directory. [Example PR](https://github.com/grafana/loki/pull/10840/commits/0d4416a4b03739583349934b96f272fb4f685d15)
