### PR TITLE
Fix Loki version in image-references

### DIFF
--- a/operator/bundle/image-references
+++ b/operator/bundle/image-references
@@ -6,7 +6,7 @@ spec:
   - name: logging-loki-rhel9
     from:
       kind: DockerImage
-      name: quay.io/openshift-logging/loki:v3.6.5
+      name: quay.io/openshift-logging/loki:v3.5.5
   - name: lokistack-gateway-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
This file needs to be consistent with the version mentioned in the CSV (it's search&replace essentially).

/label tide/merge-method-squash
/cc @JoaoBraveCoding 
/assign @xperimental 