### PR TITLE
Update ART information for Loki 3.7.2

### DIFF
--- a/operator/bundle/art.yaml
+++ b/operator/bundle/art.yaml
@@ -3,8 +3,6 @@ updates:
 # relative to this file
 - file: "openshift/manifests/loki-operator.clusterserviceversion.yaml"
   update_list:
-  - search: "quay.io/openshift/origin-kube-rbac-proxy:latest"
-    replace: "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:b30b0bcd2199e73ce519ed106ba4a923b2c5aadc8698816a53ea56b770caf683"
   - search: "0.1.0"
     replace: "6.6.0"
   - search: "olm.skipRange: '>=6.0.0-0 <6.2.0'"

--- a/operator/bundle/image-references
+++ b/operator/bundle/image-references
@@ -6,7 +6,7 @@ spec:
   - name: logging-loki-rhel9
     from:
       kind: DockerImage
-      name: quay.io/openshift-logging/loki:v3.6.5
+      name: quay.io/openshift-logging/loki:v3.7.2
   - name: lokistack-gateway-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the metadata used by ART for rewriting the bundle to point to Loki 3.7.2.

This also removes the mention of `kube-rbac-proxy` in the configuration as we do not need it anymore.

Depends on #510

Refs [LOG-9434](https://redhat.atlassian.net/browse/LOG-9434)

/label tide/merge-method-squash
/cc @JoaoBraveCoding 
/assign @xperimental 
