### PR TITLE
Replace passthrough-gateway reference with operator image in ART build

### DIFF
--- a/operator/bundle/image-references
+++ b/operator/bundle/image-references
@@ -19,3 +19,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift-logging/loki-operator:0.1.0
+  - name: loki-rhel9-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift-logging/passthrough-gateway:latest


### PR DESCRIPTION
**What this PR does / why we need it**:

The staging build currently fails to validate the CSV because it references the upstream `passthrough-gateway` image. This PR intends to replace that reference with the operator image. While this will not produce a working LokiStack when combined with the new tenancy mode, it is meant as a quick-fix for the staging release.

/cc @btaani @JoaoBraveCoding 
/assign @xperimental 
/label tide/merge-method-squash
