### PR TITLE
Add missing vendored files

### DIFF
--- a/vendor/go.yaml.in/yaml/v4/.golangci.yaml
+++ b/vendor/go.yaml.in/yaml/v4/.golangci.yaml
@@ -1,0 +1,54 @@
+# Copyright 2025 The go-yaml Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+version: '2'
+
+linters:
+  enable:
+  - dupword
+  - govet
+  - mirror
+  - misspell
+  - nolintlint
+  - staticcheck
+  - modernize
+  - nilnesserr
+  - thelper
+  - unconvert
+  disable:
+  - errcheck
+  - ineffassign
+  - unused
+  settings:
+    dupword:
+      ignore:
+      - 'NULL'
+      - DOCUMENT-START
+      - BLOCK-END
+    misspell:
+      locale: US
+    nolintlint:
+      allow-unused: false
+      require-specific: true
+      require-explanation: true
+    govet:
+      enable-all: true
+      disable:
+      - fieldalignment
+      - shadow
+    staticcheck:
+      checks:
+      # enable all rules
+      - all
+      # disable some of them
+      - -QF1001  # De Morgan's laws is too opinionated.
+      - -ST1003  # The codebase has too many underscores in identifiers for now.
+
+formatters:
+  enable:
+  - gofumpt
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  uniq-by-line: false

--- a/vendor/go.yaml.in/yaml/v4/.ls-lint.yaml
+++ b/vendor/go.yaml.in/yaml/v4/.ls-lint.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025 The go-yaml Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# The ls-lint configuration file.
+# More information on the file format can be found on https://ls-lint.org/
+ls:
+  # root directory
+  .yml: exists:0      # .yml files
+  .*.yml: exists:0    # .yml dotfiles
+
+  # any subdirectory, even dotfile directory
+  '**':
+    .yml: exists:0    # .yml files
+    .*.yml: exists:0  # .yml dotfiles
+
+ignore:
+- .git          # git folder
+- .cache        # cache folder
+- yts/testdata  # third-party folder

--- a/vendor/go.yaml.in/yaml/v4/.yamllint.yaml
+++ b/vendor/go.yaml.in/yaml/v4/.yamllint.yaml
@@ -1,0 +1,22 @@
+# Copyright 2025 The go-yaml Project Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+extends: default
+
+ignore: /**/testdata/  # ignore testdata files that are not relevant for linting
+
+rules:
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 1  # allow us to use space in brackets
+  document-start:
+    present: false
+  indentation:
+    spaces: 2
+    indent-sequences: false  # make sure there is no indentation for sequences
+  truthy:
+    check-keys: false  # there is a problem with the "on" key in GitHub Actions
+  quoted-strings:
+    check-keys: true  # by default, only values are checked
+    quote-type: single
+    required: only-when-needed


### PR DESCRIPTION
**What this PR does / why we need it**:

The `vendor` folder is missing some files of `yaml/v4` because its own gitignore skips them. This PR adds those files to fix the downstream build.

/cc @btaani @JoaoBraveCoding 
/assign @xperimental 
/label tide/merge-method-squash
