### PR TITLE
Update skipRange to support direct upgrade from 6.2 to 6.6

### DIFF
--- a/operator/bundle/art.yaml
+++ b/operator/bundle/art.yaml
@@ -6,4 +6,4 @@ updates:
   - search: "0.1.0"
     replace: "6.6.0"
   - search: "olm.skipRange: '>=6.0.0-0 <6.2.0'"
-    replace: "olm.skipRange: '>=6.4.0-0 <6.6.0'"
+    replace: "olm.skipRange: '>=6.2.0-0 <6.6.0'"


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjusts the `skipRange` so that direct upgrades from Logging 6.2.0 and above are possible.

**Which issue(s) this PR fixes**:

Fixes [LOG-9508](https://redhat.atlassian.net/browse/LOG-9508)

/cc @btaani @JoaoBraveCoding 
/assign @xperimental 
/label tide/merge-method-squash