### PR TITLE
Change build version from arg to env var

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -5,7 +5,7 @@ ENV CGO_ENABLED=1
 ENV GOOS=linux
 ENV GOFLAGS="-mod=vendor -p=4"
 
-ARG BUILD_VERSION=3.7.2
+ENV BUILD_VERSION=3.7.2
 ARG SOURCE_GIT_COMMIT
 ENV LOKI_VPREFIX="github.com/grafana/loki/v3/pkg/util/build"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes `BUILD_VERSION` from being a build argument to an environment variable. It looks as if this argument is used by ART and contains the "product version" (for example `6.0.0`) leading to wrong build information on the Loki binary.

An alternative solution would be to rename `BUILD_VERSION` in the Dockerfile to something that is not used by ART, for example `LOKI_VERSION`.

**Which issue(s) this PR fixes**:

Fixes [LOG-9513](https://redhat.atlassian.net/browse/LOG-9513)

/cc @JoaoBraveCoding 
/assign @xperimental 
/label tide/merge-method-squash
/hold until we have decided whether we want to keep BUILD_VERSION or rename the variable
