### PR TITLE
Update ART information for Loki 3.7.3

### DIFF
--- a/operator/bundle/image-references
+++ b/operator/bundle/image-references
@@ -6,7 +6,7 @@ spec:
   - name: logging-loki-rhel9
     from:
       kind: DockerImage
-      name: quay.io/openshift-logging/loki:v3.7.2
+      name: quay.io/openshift-logging/loki:v3.7.3
   - name: lokistack-gateway-rhel9
     from:
       kind: DockerImage


### PR DESCRIPTION
What this PR does / why we need it:

Updates the metadata used by ART for rewriting the bundle to point to Loki 3.7.3.

Depends on https://github.com/openshift/loki/pull/520

Refs https://redhat.atlassian.net/browse/LOG-9540

/label tide/merge-method-squash
/cc @xperimental
/assign @JoaoBraveCoding